### PR TITLE
Remove misleading dormant router logic comments

### DIFF
--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -1012,9 +1012,6 @@ async def chat_completions(
         raise HTTPException(status_code=500, detail=f"Router Error: {str(e)}")
 
 
-# Legacy endpoint logic preserved below for reference but bypassed by return above
-# To fully replace, we should comment out or remove the old logic.
-# For now, I will effectively replace the entire function body with the router call.
 
 
 @app.post("/v1/embeddings")


### PR DESCRIPTION
## Summary
- Remove misleading comments suggesting dormant legacy code exists
- Document that the router migration is complete
- Clean up TODO-style comments that were causing confusion

## Investigation Findings
After investigating the "dormant router logic" in main.py:

1. **chat_completions endpoint** properly delegates to `RouterWrapper`
2. **No actual dormant code exists** - the function body only uses the router
3. **Comments were misleading** - they suggested legacy code was "preserved" but none existed

## Changes Made
- Removed misleading comments at lines 1015-1017 that suggested legacy code existed
- The chat_completions endpoint is clean and properly uses RouterWrapper for all routing

## Technical Details
The `chat_completions` function:
- Calls `router = get_router()` to get the RouterWrapper instance
- Calls `await router.handle_chat_completions(request, client)` for routing
- Raises HTTPException if routing fails

No legacy/dormant code was found that needed removal.

Closes #122