### PR TITLE
fix(gateway): strip provider prefix in litellm fallback (Provider NOT provided)

### DIFF
--- a/src/proxy_app/litellm_fallback.py
+++ b/src/proxy_app/litellm_fallback.py
@@ -1,0 +1,44 @@
+"""Build kwargs for `litellm.acompletion` when the adapter factory fails.
+
+Pure helper module. No litellm import here so tests stay hermetic.
+"""
+
+from typing import Any, Dict, Optional
+
+
+def build_litellm_fallback_kwargs(
+    request_clean: Dict[str, Any],
+    provider: str,
+    model: str,
+    api_key: Optional[str],
+    api_base: Optional[str],
+) -> Dict[str, Any]:
+    """Build kwargs for `litellm.acompletion` when the adapter factory fails.
+
+    Free providers like `kilo`, `aihubmix`, `zanity`, `paxsenix` are NOT
+    known providers in litellm. Passing `model=f"{provider}/{model}"`
+    directly causes litellm to parse `provider` as the upstream name,
+    then fail with `BadRequestError: LLM Provider NOT provided` because
+    it has no api_key, no api_base, and no provider class for that name.
+
+    We solve this by:
+      1. Stripping the provider prefix from `model` (litellm gets the
+         raw upstream model id).
+      2. Forcing `custom_llm_provider="openai"` so litellm uses the
+         OpenAI-compatible code path.
+      3. Passing through the resolved `api_key` and `api_base` from the
+         provider config (env-resolved upstream).
+      4. Falling back to the literal sentinel `"EMPTY"` if the env
+         variable is unset — the upstream provider may accept no auth
+         (e.g. a public demo endpoint) and litellm would otherwise
+         refuse to dispatch.
+    """
+    kwargs: Dict[str, Any] = {
+        **request_clean,
+        "model": model,
+        "api_key": api_key if api_key else "EMPTY",
+        "custom_llm_provider": "openai",
+    }
+    if api_base:
+        kwargs["api_base"] = api_base
+    return kwargs

--- a/src/proxy_app/router_core.py
+++ b/src/proxy_app/router_core.py
@@ -27,6 +27,8 @@ from .rate_limiter import REASON_RATE_LIMIT, REASON_USAGE_CAP
 
 logger = logging.getLogger(__name__)
 
+from .litellm_fallback import build_litellm_fallback_kwargs  # noqa: E402
+
 
 class ProviderStatus(Enum):
     """Provider health status."""
@@ -874,14 +876,16 @@ class RouterCore:
                 )
                 response = await adapter.chat_completions(request_clean)
             except ValueError:
-                # Fallback to LiteLLM direct usage
-                # Special handling for G4F if not in adapter factory (but it is now)
-                if candidate.provider == "g4f":
-                    # This path shouldn't be reached if G4F is in factory
-                    pass
-
-                # Execute
-                response = await litellm.acompletion(**request_clean, stream=False)
+                # Fallback to LiteLLM direct usage for providers without an adapter.
+                # See `build_litellm_fallback_kwargs` docstring for rationale.
+                fallback_kwargs = build_litellm_fallback_kwargs(
+                    request_clean,
+                    candidate.provider,
+                    candidate.model,
+                    api_key,
+                    api_base,
+                )
+                response = await litellm.acompletion(**fallback_kwargs, stream=False)
 
             # Record success
             elapsed_ms = (time.time() - start_time) * 1000
@@ -1788,7 +1792,15 @@ class RouterCore:
                 )
             except ValueError:
                 # Fallback to LiteLLM direct usage for providers without an adapter.
-                response = await litellm.acompletion(**request_clean, stream=True)
+                # See `build_litellm_fallback_kwargs` docstring for rationale.
+                fallback_kwargs = build_litellm_fallback_kwargs(
+                    request_clean,
+                    candidate.provider,
+                    candidate.model,
+                    api_key,
+                    api_base,
+                )
+                response = await litellm.acompletion(**fallback_kwargs, stream=True)
 
             chunk_count = 0
             async for chunk in response:

--- a/tests/test_litellm_fallback_kwargs.py
+++ b/tests/test_litellm_fallback_kwargs.py
@@ -1,0 +1,122 @@
+"""Tests for `build_litellm_fallback_kwargs`.
+
+Regression: when the adapter factory cannot create an adapter for a free
+provider (`kilo`, `aihubmix`, `zanity`, `paxsenix`, ...), the gateway
+falls back to `litellm.acompletion`. Previously this passed
+`model="kilo/meta-llama/llama-3.3"` with no api_key and no api_base,
+which made litellm raise
+`litellm.BadRequestError: LLM Provider NOT provided` because "kilo" is
+not a known litellm provider and there was nothing to dispatch with.
+
+The fix: strip the provider prefix from the model, force
+`custom_llm_provider="openai"`, and pass through the env-resolved
+api_key / api_base. We also fall back to the literal "EMPTY" api_key
+when the upstream endpoint accepts no auth.
+"""
+
+import pytest
+
+from src.proxy_app.litellm_fallback import build_litellm_fallback_kwargs
+
+
+class TestBuildLitellmFallbackKwargs:
+    def test_strips_provider_prefix_from_model(self):
+        """The model string must be the bare upstream id, not 'provider/model'."""
+        request_clean = {"model": "kilo/meta-llama/llama-3.3-70b-instruct:free"}
+        kwargs = build_litellm_fallback_kwargs(
+            request_clean=request_clean,
+            provider="kilo",
+            model="meta-llama/llama-3.3-70b-instruct:free",
+            api_key="sk-kilo-xxx",
+            api_base="https://api.kilo.ai/v1",
+        )
+        assert kwargs["model"] == "meta-llama/llama-3.3-70b-instruct:free"
+        # Original request_clean must not be mutated.
+        assert request_clean["model"] == "kilo/meta-llama/llama-3.3-70b-instruct:free"
+
+    def test_forces_openai_provider(self):
+        """Without custom_llm_provider=openai, litellm can't route kilo/aihubmix."""
+        kwargs = build_litellm_fallback_kwargs(
+            request_clean={"model": "aihubmix/glm-4-flash"},
+            provider="aihubmix",
+            model="glm-4-flash",
+            api_key="sk-ahub-xxx",
+            api_base="https://aihubmix.com/v1",
+        )
+        assert kwargs["custom_llm_provider"] == "openai"
+
+    def test_passes_api_key_and_api_base(self):
+        kwargs = build_litellm_fallback_kwargs(
+            request_clean={"model": "kilo/x"},
+            provider="kilo",
+            model="x",
+            api_key="sk-kilo",
+            api_base="https://api.kilo.ai/v1",
+        )
+        assert kwargs["api_key"] == "sk-kilo"
+        assert kwargs["api_base"] == "https://api.kilo.ai/v1"
+
+    def test_empty_api_key_falls_back_to_empty_sentinel(self):
+        """When env is unset, upstream may accept no auth — use sentinel."""
+        kwargs = build_litellm_fallback_kwargs(
+            request_clean={"model": "kilo/x"},
+            provider="kilo",
+            model="x",
+            api_key=None,
+            api_base="https://api.kilo.ai/v1",
+        )
+        assert kwargs["api_key"] == "EMPTY"
+
+    def test_none_api_base_omitted(self):
+        """Don't pass api_base=None to litellm — let it default."""
+        kwargs = build_litellm_fallback_kwargs(
+            request_clean={"model": "kilo/x"},
+            provider="kilo",
+            model="x",
+            api_key="sk-kilo",
+            api_base=None,
+        )
+        assert "api_base" not in kwargs
+
+    def test_preserves_other_request_fields(self):
+        """messages, max_tokens, temperature, etc. must be carried through."""
+        request_clean = {
+            "model": "kilo/x",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 1024,
+            "temperature": 0.7,
+        }
+        kwargs = build_litellm_fallback_kwargs(
+            request_clean=request_clean,
+            provider="kilo",
+            model="x",
+            api_key="sk-kilo",
+            api_base="https://api.kilo.ai/v1",
+        )
+        assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
+        assert kwargs["max_tokens"] == 1024
+        assert kwargs["temperature"] == 0.7
+
+    @pytest.mark.parametrize(
+        "provider,model,api_base",
+        [
+            ("kilo", "meta-llama/llama-3.3-70b-instruct:free", "https://api.kilo.ai/v1"),
+            ("aihubmix", "glm-4-flash", "https://aihubmix.com/v1"),
+            ("zanity", "gpt-4o", "https://api.zanity.com/v1"),
+            ("paxsenix", "claude-3-5-sonnet", "https://api.paxsenix.com/v1"),
+            ("groq", "llama-3.1-8b-instant", "https://api.groq.com/openai/v1"),
+        ],
+    )
+    def test_realistic_provider_matrix(self, provider, model, api_base):
+        """Smoke test across all free providers that have triggered this bug."""
+        kwargs = build_litellm_fallback_kwargs(
+            request_clean={"model": f"{provider}/{model}"},
+            provider=provider,
+            model=model,
+            api_key=f"sk-{provider}-test",
+            api_base=api_base,
+        )
+        assert kwargs["model"] == model
+        assert kwargs["api_key"] == f"sk-{provider}-test"
+        assert kwargs["api_base"] == api_base
+        assert kwargs["custom_llm_provider"] == "openai"


### PR DESCRIPTION
## What

Extracts the litellm-acompletion kwargs builder out of `router_core.py` and fixes the "LLM Provider NOT provided" bug in the adapter-factory fallback path.

## Why

When the adapter factory returns a free provider it does not recognize (e.g. `kilo`, `aihubmix`, `zanity`, `paxsenix`), the gateway falls back to `litellm.acompletion`. The previous code passed `model="kilo/meta-llama/llama-3.3-70b-instruct:free"` with no `api_key`, no `api_base`, and no `custom_llm_provider`. litellm parsed the prefix as provider=`kilo` (unknown), then raised:

```
litellm.BadRequestError: LLM Provider NOT provided.
```

This was triggered on 2026-06-12 by the explore subagent routing through `vps-gateway/coding-fast`, which fell through to `kilo`, then `aihubmix`, both of which returned the same error.

## How

1. Extract the kwargs builder into `src/proxy_app/litellm_fallback.py` as `build_litellm_fallback_kwargs(request_clean, provider, model, api_key, api_base)`. Pure helper, no litellm import, fully unit-testable.
2. In `router_core.py` (both the non-stream path at ~line 820 and the stream path at ~line 1725) replace the bare `litellm.acompletion(**request_clean, ...)` with a call through the new helper. The helper:
   - **strips** the `provider/` prefix from `model`,
   - **forces** `custom_llm_provider="openai"` so litellm uses its OpenAI-compatible code path,
   - **passes through** the env-resolved `api_key` and `api_base`,
   - **falls back** to the literal sentinel `"EMPTY"` if `api_key` is unset (some upstreams accept no auth).
3. Add `tests/test_litellm_fallback_kwargs.py` with 11 parametrized tests covering all realistic free-provider shapes.

## Test plan

- [x] `python3 -m py_compile src/proxy_app/router_core.py` — clean
- [x] `python3 -m pytest tests/test_litellm_fallback_kwargs.py -v` — 11/11 passed in 0.07s
- [x] `gitleaks protect --staged` — no leaks
- [ ] On VPS: `git pull`, restart `llm-gateway.service`, retest the original explore subagent prompt → expect a non-`BadRequestError` response.

## Companion issues

- `ons96/task-board#98` — auto-switch agent models per SDLC phase (this fix unblocks the explore subagent)
- `ons96/task-board#96` — provider coverage (same class of bug: `{env:VAR}` not being resolved upstream). Both share the pattern of "router assumed the upstream adapter would do the work, fell through, then handed broken kwargs to the next layer".

Closes the bug found during the 2026-06-12 explore-subagent call.