### PR TITLE
feat(rate-limit): enforce per-provider active-day window cap (g4f 3/12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,7 @@ logs/
 cache/
 *.env
 
+# Runtime state for rate limiter (active-day tracking, etc.)
+data/
+
 oauth_creds/

--- a/config/providers_database.yaml
+++ b/config/providers_database.yaml
@@ -614,6 +614,12 @@ providers:
   - code
   rate_limits:
     rpm: 10
+  # 3 distinct calendar days per 12-day sliding window.
+  # Enforced by RateLimitTracker (data/active_days.json).
+  active_days_window:
+    window_days: 12
+    max_active_days: 3
+    tz: UTC
   notes: General G4F proxy — no API key required, rate limited
   free_models:
   - id: gpt-4o

--- a/scripts/verify_active_days.py
+++ b/scripts/verify_active_days.py
@@ -1,0 +1,206 @@
+"""CLI verification script for active-day window tracking in RateLimitTracker.
+
+Mirrors scripts/verify_rate_limiter.py: each test prints PASSED/FAILED and
+returns bool; main() exits 1 on any failure.
+
+Usage:
+    python scripts/verify_active_days.py
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Add src to path (mirrors verify_rate_limiter.py)
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from proxy_app.rate_limiter import (  # noqa: E402
+    REASON_USAGE_CAP,
+    RateLimitTracker,
+)
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _offset_day(days_ago: int) -> str:
+    return (datetime.now(timezone.utc).date() - timedelta(days=days_ago)).isoformat()
+
+
+async def test_unconfigured_provider(tracker: RateLimitTracker) -> bool:
+    print("Testing unconfigured provider...")
+    allowed, reason, info = tracker.check_active_days("noconfig")
+    if not allowed or reason != "" or info != {}:
+        print(f"FAILED: expected (True, '', {{}}), got ({allowed}, {reason!r}, {info!r})")
+        return False
+    print("PASSED: unconfigured provider always allowed")
+    return True
+
+
+async def test_under_cap_allowed(tracker: RateLimitTracker) -> bool:
+    print("Testing under cap allowed...")
+    tracker.configure_active_days_windows(
+        {"prov_under": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    # Seed two prior days, leave today unused.
+    tracker._active_days["prov_under"] = {_offset_day(5), _offset_day(2)}
+    allowed, reason, info = tracker.check_active_days("prov_under")
+    if not allowed:
+        print(f"FAILED: expected allowed, got reason={reason!r} info={info!r}")
+        return False
+    if info.get("used") != 2 or info.get("limit") != 3 or info.get("remaining") != 1:
+        print(f"FAILED: expected used=2/3 remaining=1, got {info!r}")
+        return False
+    print(f"PASSED: under cap allowed (used={info['used']}/{info['limit']})")
+    return True
+
+
+async def test_at_cap_blocked(tracker: RateLimitTracker) -> bool:
+    print("Testing at cap blocked with USAGE_CAP...")
+    tracker.configure_active_days_windows(
+        {"prov_cap": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    today = _today_utc()
+    # Seed 3 active days: today + two recent prior days. We expect blocked.
+    tracker._active_days["prov_cap"] = {today, _offset_day(1), _offset_day(3)}
+    allowed, reason, info = tracker.check_active_days("prov_cap")
+    if allowed:
+        print(f"FAILED: expected blocked, got allowed info={info!r}")
+        return False
+    if reason != REASON_USAGE_CAP:
+        print(f"FAILED: expected reason={REASON_USAGE_CAP!r}, got {reason!r}")
+        return False
+    unlock_iso = info.get("next_slot_unlocks_on")
+    if not unlock_iso:
+        print(f"FAILED: expected next_slot_unlocks_on to be set, got {info!r}")
+        return False
+    # unlock should be exactly 12 days after oldest (which is _offset_day(3))
+    expected_unlock_date = (
+        datetime.now(timezone.utc).date() - timedelta(days=3) + timedelta(days=12)
+    )
+    expected_iso = datetime.combine(
+        expected_unlock_date, datetime.min.time(), tzinfo=timezone.utc
+    ).isoformat()
+    if unlock_iso != expected_iso:
+        print(f"FAILED: expected unlock {expected_iso}, got {unlock_iso}")
+        return False
+    print(f"PASSED: at cap blocked, unlocks {unlock_iso}")
+    return True
+
+
+async def test_window_rolls_unblock(tracker: RateLimitTracker) -> bool:
+    print("Testing window roll unblocks...")
+    tracker.configure_active_days_windows(
+        {"prov_roll": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    # Seed 3 days where the OLDEST is exactly 12 days old -> should be pruned
+    # at the start of today. The other two (yesterday and 5 days ago) remain.
+    tracker._active_days["prov_roll"] = {
+        _offset_day(12),  # boundary, will be pruned
+        _offset_day(5),
+        _offset_day(1),
+    }
+    allowed, reason, info = tracker.check_active_days("prov_roll")
+    if not allowed:
+        print(f"FAILED: expected allowed after prune, got reason={reason!r} info={info!r}")
+        return False
+    if info.get("used") != 2:
+        print(f"FAILED: expected used=2 after prune, got {info!r}")
+        return False
+    print(f"PASSED: window roll pruned oldest, count={info['used']}/{info['limit']}")
+    return True
+
+
+async def test_persistence_round_trip() -> bool:
+    print("Testing persistence round-trip...")
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "active_days.json"
+        t1 = RateLimitTracker(active_days_path=path)
+        t1.configure_active_days_windows(
+            {"prov_persist": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+        )
+        # Stamp two days
+        await t1.record_active_day("prov_persist", _offset_day(4))
+        await t1.record_active_day("prov_persist", _offset_day(1))
+        if not path.exists():
+            print(f"FAILED: expected {path} to exist after record")
+            return False
+        # Reload
+        t2 = RateLimitTracker(active_days_path=path)
+        # Config is reloaded from yaml in production; in this CLI we
+        # re-configure explicitly because the persistence file only
+        # contains the dates, not the window rules.
+        t2.configure_active_days_windows(
+            {"prov_persist": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+        )
+        loaded = t2._active_days.get("prov_persist", set())
+        if loaded != {_offset_day(4), _offset_day(1)}:
+            print(f"FAILED: expected reload to restore dates, got {loaded!r}")
+            return False
+        # Sanity: check returns the right info
+        allowed, reason, info = t2.check_active_days("prov_persist")
+        if not allowed or info.get("used") != 2:
+            print(f"FAILED: expected allowed used=2 after reload, got {info!r}")
+            return False
+    print("PASSED: persistence round-trip")
+    return True
+
+
+async def test_can_use_provider_integration() -> bool:
+    print("Testing can_use_provider integration with active-day cap...")
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "active_days.json"
+        tracker = RateLimitTracker(active_days_path=path)
+        tracker.configure_active_days_windows(
+            {"g4f": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+        )
+        # Seed 3 days including today -> next request should be blocked
+        tracker._active_days["g4f"] = {
+            _today_utc(),
+            _offset_day(2),
+            _offset_day(5),
+        }
+        allowed, reason = await tracker.can_use_provider(
+            "g4f", "gpt-4o", limits={}
+        )
+        if allowed:
+            print("FAILED: expected can_use_provider to block at cap")
+            return False
+        if reason != REASON_USAGE_CAP:
+            print(f"FAILED: expected reason={REASON_USAGE_CAP!r}, got {reason!r}")
+            return False
+        # Under cap should pass
+        tracker._active_days["g4f"] = {_offset_day(1), _offset_day(4)}
+        allowed, reason = await tracker.can_use_provider(
+            "g4f", "gpt-4o", limits={}
+        )
+        if not allowed or reason != "":
+            print(f"FAILED: expected allowed under cap, got ({allowed}, {reason!r})")
+            return False
+    print("PASSED: can_use_provider honors active-day cap")
+    return True
+
+
+async def main() -> int:
+    tracker = RateLimitTracker()  # in-memory only (no path side-effects)
+    tests = [
+        await test_unconfigured_provider(tracker),
+        await test_under_cap_allowed(tracker),
+        await test_at_cap_blocked(tracker),
+        await test_window_rolls_unblock(tracker),
+        await test_persistence_round_trip(),
+        await test_can_use_provider_integration(),
+    ]
+    if all(tests):
+        print("\nAll Active-Day Tests PASSED")
+        return 0
+    print("\nSome Active-Day Tests FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/proxy_app/rate_limiter.py
+++ b/src/proxy_app/rate_limiter.py
@@ -1,9 +1,20 @@
-import time
 import asyncio
-from dataclasses import dataclass, field
-from datetime import datetime, timezone, timedelta
-from typing import Dict, Optional, Tuple, Any
+import json
 import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import date as date_cls
+from datetime import datetime, time as dt_time, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Set, Tuple
+
+try:
+    from zoneinfo import ZoneInfo
+
+    _HAS_ZONEINFO = True
+except ImportError:  # pragma: no cover - Python < 3.9
+    _HAS_ZONEINFO = False
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +25,11 @@ REASON_AUTH_FAIL = "AUTH_FAIL"
 REASON_PROVIDER_DOWN = "PROVIDER_DOWN"
 REASON_MODEL_UNAVAILABLE = "MODEL_UNAVAILABLE"
 REASON_TIMEOUT = "TIMEOUT"
+
+# Active-day tracking constants
+ACTIVE_DAYS_FILE_VERSION = 1
+DEFAULT_ACTIVE_DAYS_WINDOW_DAYS = 12
+DEFAULT_ACTIVE_DAYS_MAX = 3
 
 
 def _parse_reset_time_utc(time_str: str) -> datetime:
@@ -26,6 +42,28 @@ def _parse_reset_time_utc(time_str: str) -> datetime:
     if reset <= now:
         reset += timedelta(days=1)
     return reset
+
+
+def _resolve_tz(tz_name: str):
+    """Return a tzinfo for the given name; fall back to UTC if unavailable."""
+    if not tz_name or str(tz_name).upper() == "UTC":
+        return timezone.utc
+    if _HAS_ZONEINFO:
+        try:
+            return ZoneInfo(tz_name)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                f"Unknown timezone '{tz_name}', falling back to UTC: {e}"
+            )
+    return timezone.utc
+
+
+def _today_in_tz(tz) -> date_cls:
+    """Return the calendar date for the given tz (UTC fallback)."""
+    try:
+        return datetime.now(tz).date()
+    except Exception:  # pragma: no cover - defensive
+        return datetime.now(timezone.utc).date()
 
 
 @dataclass
@@ -46,13 +84,229 @@ class RateLimitTracker:
     """
     Tracks rate limits and usage for providers.
     Thread-safe (async-safe) implementation.
+
+    Also tracks per-provider "active days" — distinct calendar dates on which a
+    provider was used. When a provider has a configured active_days_window and
+    the number of active days inside the window exceeds the configured cap, the
+    provider is treated as usage-capped and blocked until the oldest active day
+    rolls off the window. Persistence is JSON at ``data/active_days.json`` by
+    default (path injectable for tests).
     """
 
-    def __init__(self):
+    def __init__(self, active_days_path: Optional[Path] = None):
         self._usage: Dict[str, RateLimitStatus] = {}
         self._lock = asyncio.Lock()
-        # Provider-level reset windows: provider_name -> {"daily_reset_utc": "00:00", "monthly_reset_day": 1}
+        # Provider-level reset windows: provider_name -> {"daily_reset_utc": "00:00", ...}
         self._reset_windows: Dict[str, Dict[str, Any]] = {}
+        # Active-days configuration: provider -> {"window_days", "max_active_days", "tz", "tzinfo"}
+        self._active_days_windows: Dict[str, Dict[str, Any]] = {}
+        # Active-days state: provider -> set of YYYY-MM-DD strings
+        self._active_days: Dict[str, Set[str]] = {}
+        # Persistence path. Default: <repo_root>/data/active_days.json
+        if active_days_path is None:
+            repo_root = Path(__file__).resolve().parent.parent.parent
+            active_days_path = repo_root / "data" / "active_days.json"
+        self._active_days_path: Optional[Path] = active_days_path
+        self._load_active_days()
+
+    # ------------------------------------------------------------------ #
+    # Active-days configuration + persistence                            #
+    # ------------------------------------------------------------------ #
+
+    def _load_active_days(self) -> None:
+        """Load persisted active-day state from disk if present."""
+        if not self._active_days_path or not self._active_days_path.exists():
+            return
+        try:
+            with open(self._active_days_path, "r") as f:
+                data = json.load(f)
+            providers = data.get("providers", {}) or {}
+            loaded = 0
+            for pname, pdata in providers.items():
+                if not isinstance(pdata, dict):
+                    continue
+                dates = pdata.get("dates", []) or []
+                cleaned: Set[str] = {
+                    d for d in dates if isinstance(d, str) and len(d) == 10
+                }
+                if cleaned:
+                    self._active_days[pname] = cleaned
+                    loaded += 1
+            if loaded:
+                logger.info(
+                    f"Loaded active days for {loaded} providers from "
+                    f"{self._active_days_path}"
+                )
+        except Exception as e:
+            logger.warning(
+                f"Failed to load active days from {self._active_days_path}: {e}"
+            )
+
+    def _save_active_days(self) -> None:
+        """Atomically persist active-day state to disk. No-op if path unset."""
+        if not self._active_days_path:
+            return
+        try:
+            self._active_days_path.parent.mkdir(parents=True, exist_ok=True)
+            payload: Dict[str, Any] = {
+                "version": ACTIVE_DAYS_FILE_VERSION,
+                "providers": {
+                    pname: {"dates": sorted(dates)}
+                    for pname, dates in self._active_days.items()
+                    if dates
+                },
+            }
+            tmp = self._active_days_path.with_suffix(
+                self._active_days_path.suffix + ".tmp"
+            )
+            with open(tmp, "w") as f:
+                json.dump(payload, f, indent=2, sort_keys=True)
+            os.replace(tmp, self._active_days_path)
+        except Exception as e:
+            logger.warning(
+                f"Failed to save active days to {self._active_days_path}: {e}"
+            )
+
+    def configure_active_days_windows(
+        self, windows: Dict[str, Dict[str, Any]]
+    ) -> None:
+        """Configure per-provider active-day window caps.
+
+        Example::
+
+            {"g4f": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+        """
+        self._active_days_windows = {}
+        for pname, cfg in (windows or {}).items():
+            if not isinstance(cfg, dict):
+                continue
+            wd = int(cfg.get("window_days", DEFAULT_ACTIVE_DAYS_WINDOW_DAYS))
+            md = int(cfg.get("max_active_days", DEFAULT_ACTIVE_DAYS_MAX))
+            tz_name = str(cfg.get("tz", "UTC"))
+            self._active_days_windows[pname] = {
+                "window_days": wd,
+                "max_active_days": md,
+                "tz": tz_name,
+                "tzinfo": _resolve_tz(tz_name),
+            }
+        logger.info(
+            f"Configured active-days windows for "
+            f"{len(self._active_days_windows)} providers"
+        )
+
+    def _prune_active_days(
+        self, provider: str, today: date_cls
+    ) -> Set[str]:
+        """Drop active dates older than (today - window_days + 1)."""
+        cfg = self._active_days_windows.get(provider)
+        if not cfg:
+            return set()
+        window_days = cfg["window_days"]
+        cutoff_iso = (today - timedelta(days=window_days - 1)).isoformat()
+        existing = self._active_days.setdefault(provider, set())
+        to_remove = {d for d in existing if d < cutoff_iso}
+        if to_remove:
+            existing -= to_remove
+        return existing
+
+    def check_active_days(
+        self, provider: str
+    ) -> Tuple[bool, str, Dict[str, Any]]:
+        """Check whether a provider may be used under its active-day window.
+
+        Returns ``(allowed, reason, info)``. ``info`` is a dict with::
+
+            {
+                "provider", "window_days", "max_active_days", "tz",
+                "used", "limit", "remaining",
+                "active_dates": [...],
+                "oldest_active_date": "YYYY-MM-DD" or None,
+                "next_slot_unlocks_on": ISO8601 string or None,
+            }
+        """
+        cfg = self._active_days_windows.get(provider)
+        if not cfg:
+            return True, "", {}
+        tz = cfg["tzinfo"]
+        today = _today_in_tz(tz)
+        pruned = self._prune_active_days(provider, today)
+        used = len(pruned)
+        limit = cfg["max_active_days"]
+        info: Dict[str, Any] = {
+            "provider": provider,
+            "window_days": cfg["window_days"],
+            "max_active_days": limit,
+            "tz": cfg["tz"],
+            "used": used,
+            "limit": limit,
+            "remaining": max(0, limit - used),
+            "active_dates": sorted(pruned),
+            "oldest_active_date": min(pruned) if pruned else None,
+            "next_slot_unlocks_on": None,
+        }
+        if used >= limit and pruned:
+            oldest = date_cls.fromisoformat(min(pruned))
+            unlock_date = oldest + timedelta(days=cfg["window_days"])
+            unlock_dt = datetime.combine(
+                unlock_date, dt_time(0, 0, 0), tzinfo=tz
+            )
+            info["next_slot_unlocks_on"] = unlock_dt.isoformat()
+            return False, REASON_USAGE_CAP, info
+        return True, "", info
+
+    async def record_active_day(
+        self, provider: str, date_str: Optional[str] = None
+    ) -> bool:
+        """Record that the provider was used on ``date_str`` (default: today in tz).
+
+        Returns True if the date was newly added to the set, False if it was
+        already present (or the provider is not configured for active-day
+        tracking). Persists to disk only when the set changes.
+        """
+        cfg = self._active_days_windows.get(provider)
+        if not cfg:
+            return False
+        if date_str is None:
+            today = _today_in_tz(cfg["tzinfo"])
+            date_str = today.isoformat()
+        existing = self._active_days.setdefault(provider, set())
+        if date_str in existing:
+            return False
+        existing.add(date_str)
+        # Opportunistic prune on record
+        today = _today_in_tz(cfg["tzinfo"])
+        cutoff_iso = (
+            today - timedelta(days=cfg["window_days"] - 1)
+        ).isoformat()
+        to_remove = {d for d in existing if d < cutoff_iso}
+        if to_remove:
+            existing -= to_remove
+        self._save_active_days()
+        return True
+
+    def get_active_days_info(self, provider: str) -> Dict[str, Any]:
+        """Public read-only snapshot of active-day info for a provider."""
+        _, _, info = self.check_active_days(provider)
+        return info
+
+    def list_active_days_providers(self) -> Dict[str, Dict[str, Any]]:
+        """Return a snapshot of active-day state for all known providers."""
+        result: Dict[str, Dict[str, Any]] = {}
+        providers = set(self._active_days_windows.keys()) | set(
+            self._active_days.keys()
+        )
+        for pname in sorted(providers):
+            info = self.get_active_days_info(pname)
+            cfg = self._active_days_windows.get(pname, {})
+            result[pname] = {
+                "configured": bool(cfg),
+                **info,
+            }
+        return result
+
+    # ------------------------------------------------------------------ #
+    # Existing rate-limit logic                                          #
+    # ------------------------------------------------------------------ #
 
     def configure_reset_windows(self, windows: Dict[str, Dict[str, Any]]):
         """Set known reset windows for providers.
@@ -88,10 +342,28 @@ class RateLimitTracker:
 
             status = self._usage[key]
             now = time.time()
+            prov_name = self._provider_from_key(key)
 
             # Check hard rate limit backoff
             if now < status.rate_limited_until:
                 return False, status.block_reason or REASON_RATE_LIMIT
+
+            # Active-days window check (on-the-fly; must run under lock so
+            # pruning + check are consistent with the in-memory set). If the
+            # window has rolled since the last call, this naturally recovers
+            # without needing to clear any cached backoff. Active-day state is
+            # intentionally NOT written to status.rate_limited_until: that
+            # field is reserved for record_rate_limit_hit-set cooldowns (e.g.
+            # upstream 429 responses). Active-day cap is in
+            # get_usage_stats["active_days"] and recomputed per call.
+            ad_allowed, ad_reason, ad_info = self.check_active_days(prov_name)
+            if not ad_allowed:
+                logger.debug(
+                    f"Provider {prov_name} blocked by active-day window "
+                    f"({ad_info.get('used')}/{ad_info.get('limit')}); "
+                    f"unlocks {ad_info.get('next_slot_unlocks_on')}"
+                )
+                return False, ad_reason
 
             # Reset counters if windows have passed
             if now - status.last_reset_minute > 60:
@@ -100,7 +372,6 @@ class RateLimitTracker:
                 status.last_reset_minute = now
 
             # Check if daily counter should reset based on known reset window
-            prov_name = self._provider_from_key(key)
             reset_window = self._reset_windows.get(prov_name, {})
             daily_reset_utc = reset_window.get("daily_reset_utc")
 
@@ -124,7 +395,8 @@ class RateLimitTracker:
             rpm_limit = limits.get("rpm")
             if rpm_limit and status.requests_this_minute >= rpm_limit:
                 logger.debug(
-                    f"Rate limit hit (RPM) for {key}: {status.requests_this_minute}/{rpm_limit}"
+                    f"Rate limit hit (RPM) for {key}: "
+                    f"{status.requests_this_minute}/{rpm_limit}"
                 )
                 return False, REASON_RATE_LIMIT
 
@@ -132,7 +404,8 @@ class RateLimitTracker:
             tpm_limit = limits.get("tpm")
             if tpm_limit and status.tokens_this_minute >= tpm_limit:
                 logger.debug(
-                    f"Rate limit hit (TPM) for {key}: {status.tokens_this_minute}/{tpm_limit}"
+                    f"Rate limit hit (TPM) for {key}: "
+                    f"{status.tokens_this_minute}/{tpm_limit}"
                 )
                 return False, REASON_RATE_LIMIT
 
@@ -140,7 +413,8 @@ class RateLimitTracker:
             daily_limit = limits.get("daily")
             if daily_limit and status.requests_today >= daily_limit:
                 logger.debug(
-                    f"Rate limit hit (Daily) for {key}: {status.requests_today}/{daily_limit}"
+                    f"Rate limit hit (Daily) for {key}: "
+                    f"{status.requests_today}/{daily_limit}"
                 )
                 return False, REASON_USAGE_CAP
 
@@ -148,14 +422,15 @@ class RateLimitTracker:
             daily_tokens_limit = limits.get("daily_tokens")
             if daily_tokens_limit and status.tokens_today >= daily_tokens_limit:
                 logger.debug(
-                    f"Rate limit hit (Daily Tokens) for {key}: {status.tokens_today}/{daily_tokens_limit}"
+                    f"Rate limit hit (Daily Tokens) for {key}: "
+                    f"{status.tokens_today}/{daily_tokens_limit}"
                 )
                 return False, REASON_USAGE_CAP
 
             return True, ""
 
     async def record_request(self, provider: str, model: str):
-        """Record a request attempt."""
+        """Record a request attempt and (if configured) today's active-day stamp."""
         key = self._get_key(provider, model)
         async with self._lock:
             if key not in self._usage:
@@ -163,6 +438,8 @@ class RateLimitTracker:
 
             self._usage[key].requests_this_minute += 1
             self._usage[key].requests_today += 1
+            # Stamp active day for this provider (no-op if not configured)
+            await self.record_active_day(provider)
 
     async def record_tokens(self, provider: str, model: str, token_count: int):
         """Record tokens used in a request."""
@@ -218,10 +495,10 @@ class RateLimitTracker:
             )
 
     async def get_usage_stats(self) -> Dict[str, Any]:
-        """Get current usage statistics."""
+        """Get current usage statistics, including active-day state per provider."""
         now = time.time()
         async with self._lock:
-            return {
+            usage = {
                 k: {
                     "rpm": v.requests_this_minute,
                     "daily": v.requests_today,
@@ -239,3 +516,5 @@ class RateLimitTracker:
                 }
                 for k, v in self._usage.items()
             }
+            active_days = self.list_active_days_providers()
+        return {"usage": usage, "active_days": active_days}

--- a/src/proxy_app/router_integration.py
+++ b/src/proxy_app/router_integration.py
@@ -78,9 +78,10 @@ class RouterIntegration:
         try:
             import yaml as _yaml
             from pathlib import Path as _Path
-            _db_file = _Path(
-                "/home/ubuntu/LLM-API-Key-Proxy/config/providers_database.yaml"
-            )
+            # Resolve repo root from this file's location
+            # (src/proxy_app/router_integration.py -> parents[2] = repo root)
+            _repo_root = _Path(__file__).resolve().parent.parent.parent
+            _db_file = _repo_root / "config" / "providers_database.yaml"
             if _db_file.exists():
                 with open(_db_file, "r") as _f:
                     _db = _yaml.safe_load(_f) or {}

--- a/src/proxy_app/router_integration.py
+++ b/src/proxy_app/router_integration.py
@@ -71,6 +71,40 @@ class RouterIntegration:
             if p not in provider_configs:
                 provider_configs[p] = None
 
+        # Load active-day window configs from providers_database.yaml so the
+        # rate limiter can enforce sliding-window caps (e.g. g4f: 3 active days
+        # per 12-day window).
+        active_days_windows: Dict[str, Dict[str, Any]] = {}
+        try:
+            import yaml as _yaml
+            from pathlib import Path as _Path
+            _db_file = _Path(
+                "/home/ubuntu/LLM-API-Key-Proxy/config/providers_database.yaml"
+            )
+            if _db_file.exists():
+                with open(_db_file, "r") as _f:
+                    _db = _yaml.safe_load(_f) or {}
+                for _p in _db.get("providers", []) or []:
+                    if not isinstance(_p, dict):
+                        continue
+                    _pid = _p.get("id")
+                    _adw = _p.get("active_days_window")
+                    if _pid and isinstance(_adw, dict):
+                        active_days_windows[_pid] = _adw
+        except Exception as _e:
+            logger.debug(
+                f"Could not load active_days_window configs from database: {_e}"
+            )
+        if active_days_windows:
+            try:
+                self.router.rate_limiter.configure_active_days_windows(
+                    active_days_windows
+                )
+            except Exception as _e:  # pragma: no cover - defensive
+                logger.warning(
+                    f"Failed to configure active-days windows: {_e}"
+                )
+
         for provider_name, env_var in provider_configs.items():
             if env_var is None:  # No API key needed
                 try:

--- a/tests/test_active_days_window.py
+++ b/tests/test_active_days_window.py
@@ -1,0 +1,214 @@
+"""Tests for the active-day window tracking in RateLimitTracker.
+
+Covers:
+  * unconfigured provider short-circuit
+  * under-cap / at-cap / over-cap behavior
+  * sliding-window pruning
+  * JSON persistence round-trip
+  * can_use_provider integration blocks when cap exceeded
+  * record_request stamps the active day
+  * get_usage_stats includes active_days section
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from proxy_app.rate_limiter import (
+    REASON_USAGE_CAP,
+    RateLimitTracker,
+)
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _offset_day(days_ago: int) -> str:
+    return (datetime.now(timezone.utc).date() - timedelta(days=days_ago)).isoformat()
+
+
+@pytest.fixture
+def tracker(tmp_path: Path) -> RateLimitTracker:
+    """A fresh RateLimitTracker with persistence rooted at tmp_path."""
+    return RateLimitTracker(active_days_path=tmp_path / "active_days.json")
+
+
+def test_unconfigured_provider_allowed(tracker: RateLimitTracker) -> None:
+    allowed, reason, info = tracker.check_active_days("noconfig")
+    assert allowed is True
+    assert reason == ""
+    assert info == {}
+
+
+def test_under_cap_allowed(tracker: RateLimitTracker) -> None:
+    tracker.configure_active_days_windows(
+        {"p": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    tracker._active_days["p"] = {_offset_day(5), _offset_day(2)}
+    allowed, reason, info = tracker.check_active_days("p")
+    assert allowed is True
+    assert reason == ""
+    assert info["used"] == 2
+    assert info["limit"] == 3
+    assert info["remaining"] == 1
+    assert info["window_days"] == 12
+    assert info["tz"] == "UTC"
+
+
+def test_at_cap_blocks_with_unblock_date(tracker: RateLimitTracker) -> None:
+    tracker.configure_active_days_windows(
+        {"p": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    today = _today_utc()
+    tracker._active_days["p"] = {today, _offset_day(1), _offset_day(3)}
+    allowed, reason, info = tracker.check_active_days("p")
+    assert allowed is False
+    assert reason == REASON_USAGE_CAP
+    expected_unlock = (
+        datetime.now(timezone.utc).date()
+        - timedelta(days=3)
+        + timedelta(days=12)
+    )
+    expected_iso = datetime.combine(
+        expected_unlock, datetime.min.time(), tzinfo=timezone.utc
+    ).isoformat()
+    assert info["next_slot_unlocks_on"] == expected_iso
+    assert info["oldest_active_date"] == _offset_day(3)
+    assert sorted(info["active_dates"]) == sorted(
+        tracker._active_days["p"]
+    )
+
+
+def test_window_roll_prunes_oldest(tracker: RateLimitTracker) -> None:
+    tracker.configure_active_days_windows(
+        {"p": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    tracker._active_days["p"] = {
+        _offset_day(12),  # boundary
+        _offset_day(5),
+        _offset_day(1),
+    }
+    allowed, reason, info = tracker.check_active_days("p")
+    assert allowed is True
+    assert info["used"] == 2
+    assert _offset_day(12) not in info["active_dates"]
+
+
+def test_record_active_day_dedup(tracker: RateLimitTracker) -> None:
+    tracker.configure_active_days_windows(
+        {"p": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    # First call returns True (new), second call returns False (already there).
+    assert asyncio_run(tracker.record_active_day("p", _today_utc())) is True
+    assert asyncio_run(tracker.record_active_day("p", _today_utc())) is False
+    assert tracker._active_days["p"] == {_today_utc()}
+
+
+def test_record_active_day_persists(tracker: RateLimitTracker, tmp_path: Path) -> None:
+    tracker.configure_active_days_windows(
+        {"p": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    asyncio_run(tracker.record_active_day("p", _offset_day(2)))
+    path = tmp_path / "active_days.json"
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["version"] == 1
+    assert _offset_day(2) in data["providers"]["p"]["dates"]
+
+
+def test_load_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "active_days.json"
+    t1 = RateLimitTracker(active_days_path=path)
+    t1.configure_active_days_windows(
+        {"p": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    asyncio_run(t1.record_active_day("p", _offset_day(4)))
+    asyncio_run(t1.record_active_day("p", _offset_day(1)))
+    # New instance should pick up the persisted state.
+    t2 = RateLimitTracker(active_days_path=path)
+    assert t2._active_days.get("p") == {_offset_day(4), _offset_day(1)}
+
+
+def test_can_use_provider_blocks_at_cap(tracker: RateLimitTracker) -> None:
+    tracker.configure_active_days_windows(
+        {"g4f": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    tracker._active_days["g4f"] = {
+        _today_utc(),
+        _offset_day(2),
+        _offset_day(5),
+    }
+    allowed, reason = asyncio_run(
+        tracker.can_use_provider("g4f", "gpt-4o", limits={})
+    )
+    assert allowed is False
+    assert reason == REASON_USAGE_CAP
+
+
+def test_can_use_provider_allows_under_cap(tracker: RateLimitTracker) -> None:
+    tracker.configure_active_days_windows(
+        {"g4f": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    tracker._active_days["g4f"] = {_offset_day(1), _offset_day(4)}
+    allowed, reason = asyncio_run(
+        tracker.can_use_provider("g4f", "gpt-4o", limits={})
+    )
+    assert allowed is True
+    assert reason == ""
+
+
+def test_record_request_stamps_active_day(tracker: RateLimitTracker) -> None:
+    tracker.configure_active_days_windows(
+        {"g4f": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    asyncio_run(tracker.record_request("g4f", "gpt-4o"))
+    assert _today_utc() in tracker._active_days["g4f"]
+
+
+def test_get_usage_stats_includes_active_days(tracker: RateLimitTracker) -> None:
+    tracker.configure_active_days_windows(
+        {"g4f": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    asyncio_run(tracker.record_active_day("g4f", _offset_day(2)))
+    stats = asyncio_run(tracker.get_usage_stats())
+    assert "active_days" in stats
+    assert "g4f" in stats["active_days"]
+    g4f_info = stats["active_days"]["g4f"]
+    assert g4f_info["configured"] is True
+    assert g4f_info["used"] == 1
+    assert g4f_info["limit"] == 3
+
+
+def test_unconfigured_provider_does_not_persist(tracker: RateLimitTracker, tmp_path: Path) -> None:
+    # Recording active day for a provider without config is a no-op and
+    # must not create or modify the on-disk state file.
+    result = asyncio_run(tracker.record_active_day("noconfig", _today_utc()))
+    assert result is False
+    path = tmp_path / "active_days.json"
+    assert not path.exists()
+
+
+def test_record_active_day_prunes_on_record(tracker: RateLimitTracker) -> None:
+    tracker.configure_active_days_windows(
+        {"p": {"window_days": 12, "max_active_days": 3, "tz": "UTC"}}
+    )
+    # Pre-seed with a date that is already outside the window.
+    tracker._active_days["p"] = {_offset_day(30)}
+    asyncio_run(tracker.record_active_day("p", _today_utc()))
+    # The 30-day-old entry should be pruned on record; only today remains.
+    assert tracker._active_days["p"] == {_today_utc()}
+
+
+# ---------------------------------------------------------------------------- #
+# Async runner shim for sync tests                                            #
+# ---------------------------------------------------------------------------- #
+
+def asyncio_run(coro):
+    """Run a coroutine to completion in tests (avoids pytest-asyncio dep)."""
+    import asyncio
+    return asyncio.get_event_loop().run_until_complete(coro)

--- a/tests/test_active_days_window.py
+++ b/tests/test_active_days_window.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Awaitable, TypeVar
 
 import pytest
 
@@ -22,6 +23,8 @@ from proxy_app.rate_limiter import (
     REASON_USAGE_CAP,
     RateLimitTracker,
 )
+
+T = TypeVar("T")
 
 
 def _today_utc() -> str:
@@ -208,7 +211,8 @@ def test_record_active_day_prunes_on_record(tracker: RateLimitTracker) -> None:
 # Async runner shim for sync tests                                            #
 # ---------------------------------------------------------------------------- #
 
-def asyncio_run(coro):
+def asyncio_run(coro: Awaitable[T]) -> T:
     """Run a coroutine to completion in tests (avoids pytest-asyncio dep)."""
     import asyncio
-    return asyncio.get_event_loop().run_until_complete(coro)
+
+    return asyncio.run(coro)


### PR DESCRIPTION
Re-targeted from `feat/64-g4f-active-days` to `cherry/269` after rebasing on top of #284 (distributed_gate wiring) which merged into main.

The original branch carried three older commits that conflicted with current main (HuggingFace provider, virtual-model routing, etc.). This PR now contains exactly the two commits that implement the feature:

- `b92440a` feat(rate-limit): enforce per-provider active-day window cap (g4f 3/12)
- `ef75cd1` fix(rate-limit): address PR #269 CodeRabbit review feedback

Files: +770/-29 across rate_limiter.py, router_integration.py, providers_database.yaml, .gitignore, + new tests/test_active_days_window.py and scripts/verify_active_days.py.