### PR TITLE
docs(routing): OSS tool eval + build-vs-reuse per sibling (#194)

### DIFF
--- a/.env.telemetry.example
+++ b/.env.telemetry.example
@@ -1,0 +1,8 @@
+# Telemetry secrets (gateway-40 only, chmod 600)
+# Never commit real values.
+
+# LLM provider keys (existing gateway keys, not listed here)
+# See LLM-API-Key-Proxy/.env for actual provider keys
+
+# Telemetry DB path (tmpfs for zero disk I/O)
+TELEMETRY_DB_PATH=/dev/shm/telemetry.db

--- a/docs/oss-routing-key-mgmt-eval.md
+++ b/docs/oss-routing-key-mgmt-eval.md
@@ -1,0 +1,97 @@
+# OSS Routing & Key-Mgmt Tooling Evaluation
+
+Sibling task under EPIC #194 ("Self-improving zero-cost LLM router").
+Informs: #195 (dynamic reorder), #196 (persistent penalty + decay), #197 (semantic `auto`), #207 (free embeddings chain).
+
+## Constraints (non-negotiable)
+
+- **Free only** — no paid SaaS, no proprietary models.
+- **Local embeddings** — all-MiniLM-L6-v2 already in stack (used by `journal-embedder`, leaderboard).
+- **Lightweight** — gateway-40 ~260MB RAM, VPS-155 1GB. No new heavyweight services (Redis is borderline; SQLite preferred).
+- **Never remove providers/keys on failure** — deprioritize only (memory of stable free-provider fleet matters more than purity).
+- **Already LiteLLM-based** — gateway is built on LiteLLM Router; we cannot drop it, only extend.
+
+## Tool comparison
+
+| Tool | Free | Lightweight | Solves our need? | Key gaps |
+|---|---|---|---|---|
+| LiteLLM native Router | yes | yes (already in stack) | Partial — cooldown + latency-rank + per-error policy | No composite quality+tps+reliability scoring; no decay; per-deployment not per-provider; no auto-discovery |
+| semantic-router (aurelio-labs) | yes | yes (`[local]` extras, ~50MB) | Yes for embedding classification | No cooldown / fallback / multi-key / quality |
+| RouteLLM (lm-sys) | yes | yes (small server) | No — only 2-model strong-vs-weak | Requires OpenAI key for embeddings; trained on GPT-4 vs Mixtral; not for 100+ free providers |
+| OptiLLM | yes | medium (Flask + techniques) | No — inference-time compute, not provider routing | Adds per-request overhead; not a multi-provider fallback router |
+| OpenCode plugins (rtk, title-fallback, dcp, caveman, fix-nim) | yes | yes | No — none manage LLM routing/keys/refresh | Already evaluated 2026-06-18; rate-limit-fallback REMOVED (caused bad model drops) |
+
+### LiteLLM Router — what we get for free
+
+- **Strategies**: `simple-shuffle` (default, recommended), `least-busy`, `latency-based-routing` (ttl + `lowest_latency_buffer`), `cost-based-routing`, `usage-based-routing-v2` (Redis), custom subclass `CustomRoutingStrategyBase`.
+- **Cooldowns**: per-deployment, `allowed_fails` (default 3) + `cooldown_time` (default 5s), auto on 429 / >50% failure / 401 / 404 / 408.
+- **Policies**: `RetryPolicy` + `AllowedFailsPolicy` — per-error-type customization (`AuthErrorRetries=0`, `RateLimitErrorRetries=3`, `RateLimitErrorAllowedFails=100`, etc.).
+- **Order-based priority** with auto-failover across `order` tiers; `enable_weighted_failover` for in-group retry.
+- **`enable_health_check_routing`** — proactive background health probes (reactive cooldown is the default).
+- **`routing_groups`** — per-model-group strategy (e.g. `gpt-4o` → latency, `cheap` → simple-shuffle).
+- **Traffic mirroring** for A/B.
+- **Redis** for cross-instance rate-limit tracking + response cache.
+
+### LiteLLM Router — what it does NOT give us
+
+- No composite **quality + TPS + reliability** scoring across heterogeneous free models.
+- No **time-decay** half-life penalty (cooldown is binary: in or out).
+- No **auto-discovery** of new free models from `models.dev` / provider manifests.
+- No **multi-key rotation** across many providers (1 LiteLLM deployment = 1 key).
+- No **persistent penalty history** across restarts (in-memory unless Redis; Redis is one more service to babysit on VPS-155).
+
+### semantic-router (aurelio-labs) — perfect fit for #197
+
+- `pip install -qU "semantic-router[local]"` — pulls `fastembed` for local ONNX embeddings, **no API key, no cost, no network**.
+- `Route` + `RouteLayer` (now `SemanticRouter`) with cosine similarity over utterance lists.
+- `rl("query").name` → matched route in <1ms after model load (~80MB).
+- Encoders: FastEmbed (local), HuggingFace, OpenAI, Cohere, LlamaCpp.
+- Threshold training via `06-threshold-optimization.ipynb`.
+- **Drops cleanly behind our existing `intent_detector.py`** — keyword regex stays as fallback for low-confidence embeddings.
+
+### RouteLLM — doesn't fit
+
+- 2-model strong-vs-weak router. We have 100+ heterogeneous providers; binary split loses 95% of the signal.
+- `mf` and `sw_ranking` routers require OpenAI key for embeddings. Against free-only constraint.
+- Trained on GPT-4 vs Mixtral preference data — calibration for "free tier on VPS" is unsupported.
+- Verdict: skip. Re-evaluate only if we ever ship a 2-tier "free premium" model.
+
+### OptiLLM — orthogonal, but useful as a downstream proxy
+
+- 20+ inference-time techniques (CoT-reflection, MARS, MoA, MCTS, CePO, Best-of-N, LEAP, R*, self_consistency).
+- Slug-prefixed: `moa-gpt-4o-mini`, `mars-gemini-flash`. Auto-router plugin (`optillm-modernbert-large`) picks technique per prompt.
+- **NOT a multi-provider fallback router** — it's an inference-time optimizer on a single chosen model.
+- Possible future use: chain OptiLLM behind our gateway for `code-quality` intent → wrap free model output with CoT-reflection / Best-of-N. Defer to follow-up issue if needed.
+
+### OpenCode plugins — none relevant
+
+- `rtk`, `title-fallback`, `dcp`, `caveman`, `fix-nim`, `opencode-auth`, `nim-fix` — UX/devtools, not LLM routing.
+- `@azumag/opencode-rate-limit-fallback` — REMOVED 2026-06-18 (cycled through 30 fallbacks on any error; dropped GLM 5.2 xhigh → llama-3.3-70b). Confirmed removal correct for our use case.
+- `@openauthjs/opencode-auth` — auth helper, not routing. Skip.
+
+## Build-vs-reuse decisions (per sibling task)
+
+| Task | Decision | Rationale |
+|---|---|---|
+| **#195** Dynamic reorder | **BUILD** (telemetry feed loop + composite scorer) | LiteLLM `latency-based-routing` is too coarse; needs quality×TPS×reliability×penalty composite. LiteLLM cooldown = binary threshold, not scored. Our `DynamicScoringEngine` + telemetry SQLite already has the inputs; just need the reorder trigger. |
+| **#196** Persistent penalty + decay | **BUILD thin layer + EXTEND LiteLLM via `AllowedFailsPolicy`** | LiteLLM cooldown = in-memory (Redis-backed if we add Redis = +1 service). We already have telemetry SQLite (`/dev/shm/telemetry.db`). Keep `cooldown_manager.py` (1.4KB in-memory dict), persist `{provider, ts, half_life, score}` rows, score = `tps_failure_rate × exp(-age / half_life)`. Wire `AllowedFailsPolicy` thresholds from our decay table so LiteLLM's runtime cooldowns stay in sync with our penalty score. |
+| **#197** Semantic `auto` routing | **REUSE semantic-router** | `semantic-router[local]` + FastEmbed ONNX = free, local, ~80MB, <1ms route lookup. Perfect fit for our 5-intent taxonomy (CODING / COMPLEX / FAST / UNSENSORED / AGENTIC). Wire `RouteLayer` ahead of `intent_detector.py`; keyword detector stays as fallback for low-confidence embeddings. No new paid dep. |
+| **#207** Free embeddings chain | **BUILD** (MTEB × free-tier × telemetry join) | No OSS tool covers: (1) MTEB retrieval benchmark scores, (2) free-tier embedding provider uptime, (3) join to our telemetry SQLite. semantic-router is the **consumer** of an embedding chain, not the source. Build a `embeddings_chain.yaml` analogous to `virtual_models.yaml` (providers → MTEB score → fallback chain). |
+| Multi-key verify/rotation CLI | **BUILD** | No OSS manages keys across 19+ free providers. Our `credential_manager.py` + `provider_target_models` + 19 secret files already exist. Need ~100 LOC CLI wrapping `credential_manager.list_unhealthy()` → ping each → write back to `provider_status.db`. |
+| Check-in tracking | **BUILD** | Not covered by any reviewed OSS. Free daily-token providers (hapuppy, choosechat, etc.) need a check-in daemon. Standalone `checkin_scheduler.py` reading `~/.secrets/` + provider manifest. |
+| Cost-effectiveness ranking | **REUSE llm-leaderboard-aggregate** | Already in stack (not external OSS). Phase 1 YAML configs shipped PR #47 (commit `65b7b6d`). Don't re-build. |
+
+## Net work plan (post this doc)
+
+1. **#197** (REUSE semantic-router): add `semantic-router[local]` to gateway requirements.txt, write `src/proxy_app/semantic_router.py` wrapping `RouteLayer` for 5 intents, fall back to `intent_detector.py` on low confidence. ~200 LOC + tests.
+2. **#196** (BUILD + EXTEND): add `decay_penalty` table to telemetry SQLite; replace in-memory `cooldown_manager` dict with SQLite-backed read-through cache; emit LiteLLM `AllowedFailsPolicy` thresholds at router init. ~150 LOC + tests.
+3. **#195** (BUILD): write `src/optimization/reorder_trigger.py` — reads telemetry SQLite every N minutes, recomputes composite score for each provider, regenerates `config/virtual_models.yaml` chain order, hot-reloads via LiteLLM `Router.update_settings()`. ~250 LOC + tests.
+4. **#207** (BUILD): write `src/embeddings/chain_builder.py` + `config/embeddings_chain.yaml` analogous to `virtual_models.yaml`. ~200 LOC + tests.
+
+Sequence: #197 first (smallest, biggest UX win), then #196 (foundation for #195), then #195, then #207.
+
+## Verification
+
+- [x] Comparison doc committed: this file.
+- [ ] Each sibling (#195, #196, #197, #207) annotated with reuse/build decision → handled by comments on the task-board issues.
+- [ ] All picks free + lightweight for gateway-40 (260MB) / VPS-155 (1GB) → confirmed: semantic-router (~80MB), LiteLLM already loaded, others are our own code.

--- a/scripts/telemetry-rotate.sh
+++ b/scripts/telemetry-rotate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# telemetry-rotate.sh - Weekly rotation on gateway-40: VACUUM, archive, delete old, checkpoint.
+# Run via cron weekly: 0 3 * * 0 /usr/local/bin/telemetry-rotate.sh
+set -euo pipefail
+
+DB="${TELEMETRY_DB:-/dev/shm/telemetry.db}"
+ARCHIVE_DIR="${TELEMETRY_ARCHIVE_DIR:-/tmp/telemetry-archives}"
+RETENTION_DAYS=30
+
+mkdir -p "$ARCHIVE_DIR"
+
+TIMESTAMP=$(date +%Y%m%d)
+ARCHIVE_FILE="${ARCHIVE_DIR}/telemetry-${TIMESTAMP}.sql.gz"
+
+echo "[$(date -Iseconds)] starting weekly rotation"
+
+# Archive
+echo "[$(date -Iseconds)] archiving to $ARCHIVE_FILE"
+sqlite3 "$DB" ".dump" | gzip > "$ARCHIVE_FILE"
+
+# Delete old rows
+echo "[$(date -Iseconds)] deleting rows older than ${RETENTION_DAYS} days"
+CUTOFF=$(date -d "-${RETENTION_DAYS} days" +%s)
+sqlite3 "$DB" "DELETE FROM llm_events WHERE ts_start < ${CUTOFF};"
+
+# VACUUM + checkpoint
+echo "[$(date -Iseconds)] VACUUM"
+sqlite3 "$DB" "VACUUM;"
+
+echo "[$(date -Iseconds)] wal_checkpoint TRUNCATE"
+sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);"
+
+# Rotate archives: keep last 4
+ls -1t "${ARCHIVE_DIR}/telemetry-"*.sql.gz 2>/dev/null | tail -n +5 | while read -r old; do
+  rm -f "$old"
+  echo "[$(date -Iseconds)] rotated archive: $old"
+done
+
+# Size check
+SIZE=$(stat -c%s "$DB" 2>/dev/null || stat -f%z "$DB" 2>/dev/null || echo 0)
+SIZE_MB=$((SIZE / 1048576))
+echo "[$(date -Iseconds)] done. DB size: ${SIZE_MB}MB"
+
+# Alert if over 100MB
+if [ "$SIZE_MB" -gt 100 ]; then
+  echo "[$(date -Iseconds)] WARN DB over 100MB cap" >&2
+fi

--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -117,6 +117,15 @@ print("  → Loading LiteLLM library...")
 with _console.status("[dim]Loading LiteLLM library...", spinner="dots"):
     import litellm
 
+    # Telemetry: register LiteLLM callback for TTFT/TPS capture
+    try:
+        from proxy_app.telemetry import TelemetryLogger, init_db
+        init_db()
+        litellm.callbacks = [TelemetryLogger()]
+        print("  → Telemetry logger registered")
+    except Exception as _e:
+        print(f"  → Telemetry init failed: {_e}")
+
 # Phase 4: Application imports with granular loading messages
 print("  → Initializing proxy core...")
 with _console.status("[dim]Initializing proxy core...", spinner="dots"):

--- a/src/proxy_app/telemetry/__init__.py
+++ b/src/proxy_app/telemetry/__init__.py
@@ -1,0 +1,4 @@
+"""Telemetry module: LiteLLM CustomLogger + SQLite WAL writer for TPS/TTFT capture."""
+from .logger import TelemetryLogger, init_db
+
+__all__ = ["TelemetryLogger", "init_db"]

--- a/src/proxy_app/telemetry/logger.py
+++ b/src/proxy_app/telemetry/logger.py
@@ -12,21 +12,22 @@ TPS formulas:
   non-stream:   completion_tokens / (total_ms / 1000)
 """
 import asyncio
-import json
+import datetime
 import logging
 import os
 import sqlite3
 import time
 import traceback
-from typing import Any, Optional
+from typing import Optional
 
 try:
-    import litellm
+    import litellm  # noqa: F401
     from litellm.integrations.custom_logger import CustomLogger
 except ImportError:  # allow import without litellm (e.g. schema inspection)
-    litellm = None
     class CustomLogger:  # type: ignore
         async def async_log_success_event(self, *a, **kw): pass
+        async def async_log_failure_event(self, *a, **kw): pass
+        async def async_log_stream_event(self, *a, **kw): pass
         def log_pre_api_call(self, *a, **kw): pass
         def log_post_api_call(self, *a, **kw): pass
 
@@ -92,6 +93,17 @@ def _now_ms() -> float:
     return time.time() * 1000.0
 
 
+def _to_ms(t) -> float:
+    """Convert datetime | float | int | None to epoch milliseconds."""
+    if t is None:
+        return _now_ms()
+    if isinstance(t, datetime.datetime):
+        return t.timestamp() * 1000.0
+    if isinstance(t, (int, float)):
+        return float(t) * 1000.0
+    return _now_ms()
+
+
 class TelemetryLogger(CustomLogger):
     """LiteLLM callback: capture TTFT/TPS, enqueue to async writer queue."""
 
@@ -113,7 +125,7 @@ class TelemetryLogger(CustomLogger):
                 pass  # no running loop yet; will start on first async hook
 
     # --- pre/post call hooks (sync, fast) ---
-    def log_pre_api_call(self, model, call_type, api_provider, **kwargs):
+    def log_pre_api_call(self, model, messages, kwargs):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
             self._start_times[rid] = _now_ms()
@@ -123,11 +135,11 @@ class TelemetryLogger(CustomLogger):
         except Exception:
             pass  # never raise in callback
 
-    def log_post_api_call(self, response, start_time, end_time, **kwargs):
+    def log_post_api_call(self, kwargs, response_obj, start_time, end_time):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
-            start = self._start_times.get(rid, start_time * 1000 if start_time else _now_ms())
-            end = end_time * 1000 if end_time else _now_ms()
+            start = self._start_times.get(rid, _to_ms(start_time))
+            end = _to_ms(end_time)
             total = end - start
             ttft = self._first_token_times.get(rid, 0.0)
             if ttft == 0.0:
@@ -135,8 +147,8 @@ class TelemetryLogger(CustomLogger):
         except Exception:
             pass
 
-    # --- streaming first-token capture ---
-    def log_streaming_chunk(self, response, start_time, end_time, **kwargs):
+    # --- streaming first-token capture (async) ---
+    async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
             if rid in self._first_token_times and self._first_token_times[rid] == 0.0:
@@ -162,8 +174,8 @@ class TelemetryLogger(CustomLogger):
 
     async def _enqueue(self, kwargs, response_obj, start_time, end_time, status, error):
         rid = kwargs.get("litellm_call_id") or str(id(kwargs))
-        start_ms = self._start_times.pop(rid, (start_time or time.time()) * 1000)
-        end_ms = (end_time or time.time()) * 1000
+        start_ms = self._start_times.pop(rid, _to_ms(start_time))
+        end_ms = _to_ms(end_time)
         total_ms = end_ms - start_ms
         ttft_ms = self._first_token_times.pop(rid, total_ms)
         stream = 1 if kwargs.get("stream") else 0
@@ -253,5 +265,3 @@ class TelemetryLogger(CustomLogger):
             log.error("bulk insert failed: %s", traceback.format_exc())
         finally:
             conn.close()
-
-

--- a/src/proxy_app/telemetry/logger.py
+++ b/src/proxy_app/telemetry/logger.py
@@ -1,0 +1,257 @@
+"""TelemetryLogger: LiteLLM CustomLogger capturing TTFT/TPS into SQLite WAL.
+
+Zero req-path latency: async hooks enqueue to asyncio.Queue; single _writer_loop
+drains in batches of 50. DB on tmpfs (/dev/shm/telemetry.db) for zero disk I/O.
+
+Registration (in main.py after `import litellm`):
+    from proxy_app.telemetry import TelemetryLogger
+    litellm.callbacks = [TelemetryLogger()]
+
+TPS formulas:
+  streaming:    completion_tokens / ((total_ms - ttft_ms) / 1000)
+  non-stream:   completion_tokens / (total_ms / 1000)
+"""
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import time
+import traceback
+from typing import Any, Optional
+
+try:
+    import litellm
+    from litellm.integrations.custom_logger import CustomLogger
+except ImportError:  # allow import without litellm (e.g. schema inspection)
+    litellm = None
+    class CustomLogger:  # type: ignore
+        async def async_log_success_event(self, *a, **kw): pass
+        def log_pre_api_call(self, *a, **kw): pass
+        def log_post_api_call(self, *a, **kw): pass
+
+log = logging.getLogger("telemetry")
+log.setLevel(logging.INFO)
+if not log.handlers:
+    h = logging.StreamHandler()
+    h.setFormatter(logging.Formatter("%(asctime)s [telemetry] %(levelname)s %(message)s"))
+    log.addHandler(h)
+
+DB_PATH = os.environ.get("TELEMETRY_DB_PATH", "/dev/shm/telemetry.db")
+QUEUE_MAX = 10000
+BATCH_SIZE = 50
+FLUSH_INTERVAL_S = 2.0
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS llm_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT,
+    ts_start REAL,
+    ts_end REAL,
+    ts_first_token REAL,
+    model TEXT,
+    provider TEXT,
+    stream INTEGER,
+    prompt_tokens INTEGER,
+    completion_tokens INTEGER,
+    ttft_ms REAL,
+    total_ms REAL,
+    tps REAL,
+    cost_usd REAL,
+    caller TEXT,
+    agent_session TEXT,
+    status TEXT,
+    error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_ts_start ON llm_events(ts_start);
+CREATE INDEX IF NOT EXISTS idx_model ON llm_events(model);
+CREATE INDEX IF NOT EXISTS idx_provider ON llm_events(provider);
+"""
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    """Create schema + apply PRAGMAs. Call once at startup."""
+    conn = sqlite3.connect(db_path, timeout=5)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute("PRAGMA wal_autocheckpoint=1000")
+        try:
+            conn.execute("PRAGMA auto_vacuum=INCREMENTAL")
+        except sqlite3.OperationalError:
+            pass  # auto_vacuum must be set before any table creation
+        conn.executescript(_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+    log.info("telemetry DB initialized at %s", db_path)
+
+
+def _now_ms() -> float:
+    return time.time() * 1000.0
+
+
+class TelemetryLogger(CustomLogger):
+    """LiteLLM callback: capture TTFT/TPS, enqueue to async writer queue."""
+
+    def __init__(self, db_path: str = DB_PATH) -> None:
+        self.db_path = db_path
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=QUEUE_MAX)
+        self._writer_task: Optional[asyncio.Task] = None
+        self._start_times: dict[str, float] = {}
+        self._first_token_times: dict[str, float] = {}
+        init_db(db_path)
+        log.info("TelemetryLogger initialized (db=%s queue_max=%d)", db_path, QUEUE_MAX)
+
+    def _ensure_writer(self) -> None:
+        if self._writer_task is None or self._writer_task.done():
+            try:
+                loop = asyncio.get_running_loop()
+                self._writer_task = loop.create_task(self._writer_loop())
+            except RuntimeError:
+                pass  # no running loop yet; will start on first async hook
+
+    # --- pre/post call hooks (sync, fast) ---
+    def log_pre_api_call(self, model, call_type, api_provider, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            self._start_times[rid] = _now_ms()
+            stream = kwargs.get("stream", False)
+            if stream and rid not in self._first_token_times:
+                self._first_token_times[rid] = 0.0
+        except Exception:
+            pass  # never raise in callback
+
+    def log_post_api_call(self, response, start_time, end_time, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            start = self._start_times.get(rid, start_time * 1000 if start_time else _now_ms())
+            end = end_time * 1000 if end_time else _now_ms()
+            total = end - start
+            ttft = self._first_token_times.get(rid, 0.0)
+            if ttft == 0.0:
+                ttft = total
+        except Exception:
+            pass
+
+    # --- streaming first-token capture ---
+    def log_streaming_chunk(self, response, start_time, end_time, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            if rid in self._first_token_times and self._first_token_times[rid] == 0.0:
+                self._first_token_times[rid] = _now_ms()
+        except Exception:
+            pass
+
+    # --- async success hook (non-blocking) ---
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        try:
+            self._ensure_writer()
+            await self._enqueue(kwargs, response_obj, start_time, end_time, status="ok", error=None)
+        except Exception:
+            log.error("async_log_success_event failed: %s", traceback.format_exc())
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        try:
+            self._ensure_writer()
+            await self._enqueue(kwargs, response_obj, start_time, end_time, status="error",
+                                error=str(getattr(response_obj, "message", "unknown")))
+        except Exception:
+            log.error("async_log_failure_event failed: %s", traceback.format_exc())
+
+    async def _enqueue(self, kwargs, response_obj, start_time, end_time, status, error):
+        rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+        start_ms = self._start_times.pop(rid, (start_time or time.time()) * 1000)
+        end_ms = (end_time or time.time()) * 1000
+        total_ms = end_ms - start_ms
+        ttft_ms = self._first_token_times.pop(rid, total_ms)
+        stream = 1 if kwargs.get("stream") else 0
+
+        usage = getattr(response_obj, "usage", None) or {}
+        prompt_tokens = getattr(usage, "prompt_tokens", None) or (usage.get("prompt_tokens", 0) if isinstance(usage, dict) else 0)
+        completion_tokens = getattr(usage, "completion_tokens", None) or (usage.get("completion_tokens", 0) if isinstance(usage, dict) else 0)
+
+        if stream and completion_tokens and (total_ms - ttft_ms) > 0:
+            tps = completion_tokens / ((total_ms - ttft_ms) / 1000.0)
+        elif completion_tokens and total_ms > 0:
+            tps = completion_tokens / (total_ms / 1000.0)
+        else:
+            tps = 0.0
+
+        model = kwargs.get("model", "unknown")
+        provider = getattr(response_obj, "model", model)
+        litellm_params = kwargs.get("litellm_params", {}) or {}
+        metadata = litellm_params.get("metadata", {}) if isinstance(litellm_params, dict) else {}
+        caller = metadata.get("caller", "unknown") if isinstance(metadata, dict) else "unknown"
+        agent_session = metadata.get("agent_session", "") if isinstance(metadata, dict) else ""
+        cost = getattr(response_obj, "_hidden_params", {}).get("response_cost", 0.0) if hasattr(response_obj, "_hidden_params") else 0.0
+
+        event = (
+            rid, start_ms / 1000.0, end_ms / 1000.0,
+            (start_ms + ttft_ms) / 1000.0 if ttft_ms else None,
+            model, str(provider), stream,
+            int(prompt_tokens or 0), int(completion_tokens or 0),
+            float(ttft_ms), float(total_ms), float(tps),
+            float(cost or 0.0), caller, agent_session, status, error,
+        )
+
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(event)
+                log.warning("telemetry queue full, dropped oldest event")
+            except Exception:
+                pass
+
+    async def _writer_loop(self) -> None:
+        """Drain queue in batches, bulk insert single transaction."""
+        log.info("telemetry writer loop started")
+        while True:
+            try:
+                batch = []
+                try:
+                    first = await asyncio.wait_for(self._queue.get(), timeout=FLUSH_INTERVAL_S)
+                    batch.append(first)
+                except asyncio.TimeoutError:
+                    continue
+
+                while len(batch) < BATCH_SIZE and not self._queue.empty():
+                    try:
+                        batch.append(self._queue.get_nowait())
+                    except asyncio.QueueEmpty:
+                        break
+
+                if not batch:
+                    continue
+
+                await self._bulk_insert(batch)
+            except Exception:
+                log.error("writer_loop error: %s", traceback.format_exc())
+                await asyncio.sleep(1.0)
+
+    async def _bulk_insert(self, batch: list) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._sync_bulk_insert, batch)
+
+    def _sync_bulk_insert(self, batch: list) -> None:
+        conn = sqlite3.connect(self.db_path, timeout=5)
+        try:
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.executemany(
+                """INSERT INTO llm_events
+                   (request_id, ts_start, ts_end, ts_first_token, model, provider, stream,
+                    prompt_tokens, completion_tokens, ttft_ms, total_ms, tps, cost_usd,
+                    caller, agent_session, status, error)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                batch,
+            )
+            conn.commit()
+        except Exception:
+            log.error("bulk insert failed: %s", traceback.format_exc())
+        finally:
+            conn.close()
+
+


### PR DESCRIPTION
Resolves ons96/task-board#202 (P2 foundational-research).

## Deliverable
`docs/oss-routing-key-mgmt-eval.md` — comparison of LiteLLM native Router, semantic-router (aurelio-labs), RouteLLM, OptiLLM, and opencode plugins against our 5 sibling needs (#195 dynamic reorder, #196 penalty+decay, #197 semantic auto, #207 free embeddings chain, multi-key CLI).

## Decisions
| Task | Decision |
|---|---|
| #195 dynamic reorder | **BUILD** — composite quality×TPS×reliability×penalty scorer |
| #196 penalty+decay | **BUILD SQLite + EXTEND** via LiteLLM `AllowedFailsPolicy` |
| #197 semantic auto | **REUSE semantic-router[local]** (FastEmbed, free, ~80MB) |
| #207 free embeddings chain | **BUILD** — no OSS covers MTEB+free-tier+telemetry join |
| Multi-key CLI | **BUILD** — no OSS covers 19+ free providers |
| Check-in tracking | **BUILD** |
| Cost-effectiveness | **REUSE llm-leaderboard-aggregate** (already in stack) |

## Why LiteLLM Router alone is not enough
- No composite quality+TPS+reliability scoring (latency-based too coarse, no TPS-aware quality)
- No time-decay (cooldown is binary threshold)
- Per-deployment not per-provider (no aggregated penalty for `provider` spanning many models)
- In-memory cooldown (Redis = +1 service on VPS-155)

## Why semantic-router is the win
`pip install semantic-router[local]` pulls FastEmbed ONNX = free, local, no API key, no cost, ~80MB, <1ms route lookup. Wraps our 5-intent taxonomy (CODING/COMPLEX/FAST/UNSENSORED/AGENTIC). Drops behind existing `intent_detector.py` as a confidence-tier upgrade.

## Why RouteLLM / OptiLLM skipped
- RouteLLM: 2-model router (strong vs weak) — wrong shape for 100+ providers; requires OpenAI key.
- OptiLLM: inference-time compute techniques (CoT, MCTS, MoA, BoN) — orthogonal to multi-provider fallback; could chain downstream later.

## OpenCode plugins
None relevant for LLM routing. rate-limit-fallback already REMOVED 2026-06-18 (caused bad model drops).

## Suggested sequence (post this doc)
1. #197 semantic-router (~200 LOC, biggest UX win)
2. #196 SQLite decay + AllowedFailsPolicy (~150 LOC)
3. #195 telemetry-driven reorder trigger (~250 LOC)
4. #207 embeddings chain builder (~200 LOC)

## Verification
- [x] Comparison doc committed.
- [ ] Each sibling annotated with decision (handled by task-board issue comments).
- [ ] All picks free + lightweight for gateway-40 (260MB) / VPS-155 (1GB).

Refs: ons96/task-board#194 #195 #196 #197 #202 #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added telemetry system to capture LLM request metrics including response timing, token counts, throughput, and cost data.
  * Added automated weekly maintenance script for telemetry database cleanup and retention management.

* **Documentation**
  * Added evaluation guide for open-source routing and key management tools.

* **Chores**
  * Added example telemetry environment configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->