### PR TITLE
feat(cli): multi-key management + dead-key verify/rotation (#198)

### DIFF
--- a/.env.telemetry.example
+++ b/.env.telemetry.example
@@ -1,0 +1,8 @@
+# Telemetry secrets (gateway-40 only, chmod 600)
+# Never commit real values.
+
+# LLM provider keys (existing gateway keys, not listed here)
+# See LLM-API-Key-Proxy/.env for actual provider keys
+
+# Telemetry DB path (tmpfs for zero disk I/O)
+TELEMETRY_DB_PATH=/dev/shm/telemetry.db

--- a/scripts/keys.py
+++ b/scripts/keys.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Multi-key management + dead-key verification CLI.
+
+Subcommands:
+    list [--provider P]                 List keys (all or per-provider) with status.
+    add PROVIDER KEY_VALUE [--id ID]    Add key, write to ~/.secrets/, update manifest.
+    remove PROVIDER ID                  Mark key removed (NEVER delete the file).
+    verify [--provider P] [--timeout T] Ping each key's provider /models endpoint.
+                                        Classify: working / dead / rate_limited / unreachable.
+    rotate PROVIDER                     Print next working key (round-robin).
+    refresh-models PROVIDER [--timeout T] Hit /v1/models, write to manifest.
+
+Storage:
+    Manifest at ~/.secrets/keys.json: {version:1, providers:{P:[KeyEntry, ...]}}
+    Key files at ~/.secrets/<provider>-key-<id> (content = key value, no newline).
+
+Exit codes: 0=success, 1=error, 2=dry-run.
+
+Refs: task-board #198. Ties into #196 penalty_store for dead-key deprioritization.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+SECRETS_DIR = Path(
+    os.environ.get("KEYS_SECRETS_DIR", os.path.expanduser("~/.secrets"))
+)
+MANIFEST_PATH = Path(
+    os.environ.get("KEYS_MANIFEST", str(SECRETS_DIR / "keys.json"))
+)
+DEFAULT_TIMEOUT = float(os.environ.get("KEYS_VERIFY_TIMEOUT", "10"))
+MANIFEST_VERSION = 1
+
+# Status enum (kept as plain strings to keep JSON human-readable).
+WORKING = "working"
+DEAD = "dead"
+RATE_LIMITED = "rate_limited"
+UNREACHABLE = "unreachable"
+UNVERIFIED = "unverified"
+REMOVED = "removed"
+
+ALL_STATUSES = {
+    WORKING,
+    DEAD,
+    RATE_LIMITED,
+    UNREACHABLE,
+    UNVERIFIED,
+    REMOVED,
+}
+ACTIVE_STATUSES = {WORKING, RATE_LIMITED, UNVERIFIED}  # not DEAD/REMOVED/UNREACHABLE
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class KeyEntry:
+    """One API key + its metadata."""
+
+    id: str
+    env_var: str = ""
+    file_path: str = ""
+    status: str = UNVERIFIED
+    last_verified: float = 0.0
+    added_at: float = field(default_factory=time.time)
+    last_used: float = 0.0
+    detail: str = ""
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: Dict) -> "KeyEntry":
+        # ponytail: tolerate missing fields from older manifests.
+        return cls(
+            id=str(d.get("id", "")),
+            env_var=str(d.get("env_var", "")),
+            file_path=str(d.get("file_path", "")),
+            status=str(d.get("status", UNVERIFIED)),
+            last_verified=float(d.get("last_verified", 0.0)),
+            added_at=float(d.get("added_at", time.time())),
+            last_used=float(d.get("last_used", 0.0)),
+            detail=str(d.get("detail", "")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+class KeyManifest:
+    """JSON-backed manifest of all keys per provider."""
+
+    def __init__(self, path: Path = MANIFEST_PATH):
+        self.path = path
+        self.providers: Dict[str, List[KeyEntry]] = {}
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.exists():
+            self.providers = {}
+            return
+        try:
+            data = json.loads(self.path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("manifest load failed (%s); starting empty", exc)
+            self.providers = {}
+            return
+        self.providers = {
+            name: [KeyEntry.from_dict(e) for e in entries]
+            for name, entries in (data.get("providers") or {}).items()
+        }
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": MANIFEST_VERSION,
+            "updated_at": time.time(),
+            "providers": {
+                name: [e.to_dict() for e in entries]
+                for name, entries in self.providers.items()
+            },
+        }
+        # ponytail: atomic write via tmp + rename.
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        tmp.replace(self.path)
+
+    # -- query --
+
+    def list_providers(self) -> List[str]:
+        return sorted(self.providers.keys())
+
+    def get_keys(self, provider: str) -> List[KeyEntry]:
+        return list(self.providers.get(provider, []))
+
+    def get_active_keys(self, provider: str) -> List[KeyEntry]:
+        return [k for k in self.get_keys(provider) if k.status in ACTIVE_STATUSES]
+
+    def next_working_key(self, provider: str) -> Optional[KeyEntry]:
+        """Round-robin: pick the working key with the oldest last_used."""
+        active = [k for k in self.get_keys(provider) if k.status == WORKING]
+        if not active:
+            return None
+        # ponytail: stable min on last_used. Ties broken by insertion order.
+        return min(active, key=lambda k: k.last_used)
+
+    # -- mutate --
+
+    def add_key(
+        self,
+        provider: str,
+        key_value: str,
+        key_id: Optional[str] = None,
+        env_var: str = "",
+        write_file: bool = True,
+    ) -> KeyEntry:
+        """Add a key. Writes the key to ~/.secrets/<provider>-key-<id> by default."""
+        entries = self.providers.setdefault(provider, [])
+        if key_id is None:
+            # ponytail: numeric ids 1, 2, ... skip collisions.
+            existing = {e.id for e in entries}
+            n = 1
+            while str(n) in existing:
+                n += 1
+            key_id = str(n)
+        file_path = ""
+        if write_file:
+            file_path = str(SECRETS_DIR / f"{provider}-key-{key_id}")
+            SECRETS_DIR.mkdir(parents=True, exist_ok=True)
+            Path(file_path).write_text(key_value)
+        entry = KeyEntry(
+            id=key_id,
+            env_var=env_var,
+            file_path=file_path,
+            status=UNVERIFIED,
+            added_at=time.time(),
+        )
+        entries.append(entry)
+        self.save()
+        return entry
+
+    def remove_key(self, provider: str, key_id: str) -> Optional[KeyEntry]:
+        """Mark a key removed (NEVER delete the file)."""
+        for entry in self.providers.get(provider, []):
+            if entry.id == key_id:
+                entry.status = REMOVED
+                entry.detail = f"marked removed at {time.time()}"
+                self.save()
+                return entry
+        return None
+
+    def update_status(
+        self,
+        provider: str,
+        key_id: str,
+        status: str,
+        detail: str = "",
+    ) -> None:
+        for entry in self.providers.get(provider, []):
+            if entry.id == key_id:
+                entry.status = status
+                entry.detail = detail
+                entry.last_verified = time.time()
+        self.save()
+
+    def mark_used(self, provider: str, key_id: str) -> None:
+        for entry in self.providers.get(provider, []):
+            if entry.id == key_id:
+                entry.last_used = time.time()
+                break
+        self.save()
+
+
+# ---------------------------------------------------------------------------
+# Provider lookup
+# ---------------------------------------------------------------------------
+
+
+def _provider_base_url(provider: str, db_path: Optional[str] = None) -> Tuple[str, str]:
+    """Look up (env_var, base_url) for a provider from llm_providers.db.
+
+    Returns ("", "") if not found. db_path defaults to the standard location.
+    """
+    if db_path is None:
+        db_path = os.environ.get(
+            "LLM_PROVIDERS_DB",
+            os.path.expanduser("~/CodingProjects/llm-provider-manager/llm_providers.db"),
+        )
+    if not os.path.exists(db_path):
+        return ("", "")
+    try:
+        import sqlite3
+
+        # ponytail: read-only URI to avoid accidental writes.
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = conn.execute(
+                "SELECT env_var, base_url FROM providers WHERE key_name=? LIMIT 1",
+                (provider,),
+            ).fetchone()
+            if row:
+                return (str(row[0] or ""), str(row[1] or ""))
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.debug("provider lookup failed for %s: %s", provider, exc)
+    return ("", "")
+
+
+def _read_key_file(path: str) -> str:
+    try:
+        return Path(path).read_text().strip()
+    except OSError:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Verify (async HTTP ping)
+# ---------------------------------------------------------------------------
+
+
+def classify_response(status_code: int, body: str = "") -> str:
+    """Map an HTTP response to a key status."""
+    if status_code == 200:
+        return WORKING
+    if status_code in (401, 403):
+        return DEAD
+    if status_code == 429:
+        return RATE_LIMITED
+    if 500 <= status_code < 600:
+        return UNREACHABLE
+    return UNVERIFIED
+
+
+async def verify_key(
+    provider: str,
+    base_url: str,
+    key_value: str,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> Tuple[str, str]:
+    """Ping a provider's /models endpoint. Returns (status, detail)."""
+    if not base_url:
+        return (UNREACHABLE, "no base_url for provider")
+    if not key_value:
+        return (DEAD, "empty key value")
+    url = base_url.rstrip("/") + "/models"
+    try:
+        import httpx
+    except ImportError:
+        return (UNREACHABLE, "httpx not installed")
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(url, headers={"Authorization": f"Bearer {key_value}"})
+        status = classify_response(resp.status_code, resp.text[:200])
+        return (status, f"HTTP {resp.status_code}")
+    except httpx.TimeoutException:
+        return (UNREACHABLE, f"timeout after {timeout}s")
+    except Exception as exc:
+        return (UNREACHABLE, f"{type(exc).__name__}: {exc}")
+
+
+async def verify_manifest(
+    manifest: KeyManifest,
+    provider: Optional[str] = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    db_path: Optional[str] = None,
+) -> List[Tuple[str, str, str, str]]:
+    """Verify all (or one provider's) keys. Returns list of
+    (provider, key_id, status, detail)."""
+    providers = [provider] if provider else manifest.list_providers()
+    results: List[Tuple[str, str, str, str]] = []
+    for name in providers:
+        env_var, base_url = _provider_base_url(name, db_path)
+        for entry in manifest.get_keys(name):
+            if entry.status == REMOVED:
+                results.append((name, entry.id, REMOVED, "skipped (removed)"))
+                continue
+            key_value = _read_key_file(entry.file_path)
+            status, detail = await verify_key(name, base_url, key_value, timeout)
+            manifest.update_status(name, entry.id, status, detail)
+            results.append((name, entry.id, status, detail))
+            # ponytail: best-effort penalty_store wire; never break verify loop.
+            if status == DEAD:
+                _try_record_penalty(name, entry.id)
+    return results
+
+
+def _try_record_penalty(provider: str, key_id: str) -> None:
+    """Best-effort: record invalid_key failure in penalty_store (#196).
+
+    Wrapped in try/except so verify works even if penalty_store isn't
+    installed or importable.
+    """
+    try:
+        # Lazy import: penalty_store lives in src/proxy_app/ on the gateway.
+        sys.path.insert(
+            0, os.path.join(os.path.dirname(__file__), "..", "src")
+        )
+        from proxy_app.penalty_store import PenaltyStore  # type: ignore
+
+        store = PenaltyStore.get()
+        # Run async call from sync context.
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                store.arecord_failure(provider, f"key-{key_id}", "invalid_key")
+            )
+        finally:
+            loop.close()
+    except Exception as exc:
+        logger.debug("penalty_store wire skipped for %s/%s: %s", provider, key_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _cmd_list(manifest: KeyManifest, args: argparse.Namespace) -> int:
+    providers = (
+        [args.provider] if args.provider else manifest.list_providers()
+    )
+    if not providers:
+        print("(no keys in manifest)")
+        return 0
+    for name in providers:
+        entries = manifest.get_keys(name)
+        if not entries:
+            continue
+        print(f"\n[{name}]  ({len(entries)} keys)")
+        for e in entries:
+            age = ""
+            if e.added_at:
+                age = f" added {time.strftime('%Y-%m-%d', time.localtime(e.added_at))}"
+            verified = ""
+            if e.last_verified:
+                verified = f" verified {time.strftime('%Y-%m-%d', time.localtime(e.last_verified))}"
+            print(
+                f"  {e.id:>4}  {e.status:<12}  {e.env_var or '-':<22}  "
+                f"{e.detail or ''}{age}{verified}"
+            )
+    return 0
+
+
+def _cmd_add(manifest: KeyManifest, args: argparse.Namespace) -> int:
+    entry = manifest.add_key(
+        args.provider,
+        args.key_value,
+        key_id=args.id,
+        env_var=args.env_var or "",
+        write_file=not args.no_file,
+    )
+    print(
+        f"added {args.provider} key id={entry.id} status={entry.status} "
+        f"file={entry.file_path or '(not written)'}"
+    )
+    return 0
+
+
+def _cmd_remove(manifest: KeyManifest, args: argparse.Namespace) -> int:
+    entry = manifest.remove_key(args.provider, args.id)
+    if entry is None:
+        print(f"error: no key id={args.id} for provider {args.provider}", file=sys.stderr)
+        return 1
+    print(
+        f"removed (marked status=removed, file NOT deleted): "
+        f"{args.provider}/{args.id} file={entry.file_path}"
+    )
+    active = manifest.get_active_keys(args.provider)
+    if not active:
+        print(
+            f"warning: no active keys remain for {args.provider} — "
+            "provider will fail until a working key is added",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def _cmd_verify(manifest: KeyManifest, args: argparse.Namespace) -> int:
+    results = asyncio.run(
+        verify_manifest(
+            manifest,
+            provider=args.provider,
+            timeout=args.timeout,
+            db_path=args.db,
+        )
+    )
+    if not results:
+        print("(no keys to verify)")
+        return 0
+    counts: Dict[str, int] = {}
+    for prov, kid, status, detail in results:
+        counts[status] = counts.get(status, 0) + 1
+        print(f"  {prov:<20} {kid:>4}  {status:<12}  {detail}")
+    print("\nsummary: " + ", ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+    # Exit nonzero if any dead keys found (useful for CI).
+    return 1 if counts.get(DEAD, 0) > 0 else 0
+
+
+def _cmd_rotate(manifest: KeyManifest, args: argparse.Namespace) -> int:
+    entry = manifest.next_working_key(args.provider)
+    if entry is None:
+        print(
+            f"error: no working key for {args.provider} "
+            "(run `keys.py verify` first or add a key)",
+            file=sys.stderr,
+        )
+        return 1
+    manifest.mark_used(args.provider, entry.id)
+    print(
+        f"rotate {args.provider}: id={entry.id} "
+        f"file={entry.file_path} env_var={entry.env_var or '-'}"
+    )
+    return 0
+
+
+def _cmd_refresh_models(manifest: KeyManifest, args: argparse.Namespace) -> int:
+    env_var, base_url = _provider_base_url(args.provider, args.db)
+    if not base_url:
+        print(f"error: no base_url for {args.provider}", file=sys.stderr)
+        return 1
+    entry = manifest.next_working_key(args.provider)
+    if entry is None:
+        print(f"error: no working key for {args.provider}", file=sys.stderr)
+        return 1
+    key_value = _read_key_file(entry.file_path)
+    url = base_url.rstrip("/") + "/models"
+
+    async def _fetch() -> Tuple[int, str]:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=args.timeout) as client:
+            resp = await client.get(
+                url, headers={"Authorization": f"Bearer {key_value}"}
+            )
+            return resp.status_code, resp.text
+
+    try:
+        status, body = asyncio.run(_fetch())
+    except Exception as exc:
+        print(f"error: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    if status != 200:
+        print(f"error: HTTP {status} from {url}", file=sys.stderr)
+        return 1
+    out_path = SECRETS_DIR / f"{args.provider}-models.json"
+    out_path.write_text(body)
+    print(f"wrote {len(body)} bytes to {out_path}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="keys.py", description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser("list", help="list keys")
+    p_list.add_argument("--provider", default=None)
+    p_list.set_defaults(func=_cmd_list)
+
+    p_add = sub.add_parser("add", help="add a key")
+    p_add.add_argument("provider")
+    p_add.add_argument("key_value")
+    p_add.add_argument("--id", default=None, help="explicit key id (default: auto)")
+    p_add.add_argument("--env-var", default="", help="env var name to record")
+    p_add.add_argument("--no-file", action="store_true", help="don't write key file")
+    p_add.set_defaults(func=_cmd_add)
+
+    p_rem = sub.add_parser("remove", help="mark a key removed (file kept)")
+    p_rem.add_argument("provider")
+    p_rem.add_argument("id")
+    p_rem.set_defaults(func=_cmd_remove)
+
+    p_ver = sub.add_parser("verify", help="ping each key's /models endpoint")
+    p_ver.add_argument("--provider", default=None)
+    p_ver.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    p_ver.add_argument("--db", default=None, help="llm_providers.db path")
+    p_ver.set_defaults(func=_cmd_verify)
+
+    p_rot = sub.add_parser("rotate", help="print next working key (round-robin)")
+    p_rot.add_argument("provider")
+    p_rot.set_defaults(func=_cmd_rotate)
+
+    p_ref = sub.add_parser("refresh-models", help="hit /v1/models, save to ~/.secrets/")
+    p_ref.add_argument("provider")
+    p_ref.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    p_ref.add_argument("--db", default=None)
+    p_ref.set_defaults(func=_cmd_refresh_models)
+
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    manifest = KeyManifest()
+    return args.func(manifest, args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/telemetry-rotate.sh
+++ b/scripts/telemetry-rotate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# telemetry-rotate.sh - Weekly rotation on gateway-40: VACUUM, archive, delete old, checkpoint.
+# Run via cron weekly: 0 3 * * 0 /usr/local/bin/telemetry-rotate.sh
+set -euo pipefail
+
+DB="${TELEMETRY_DB:-/dev/shm/telemetry.db}"
+ARCHIVE_DIR="${TELEMETRY_ARCHIVE_DIR:-/tmp/telemetry-archives}"
+RETENTION_DAYS=30
+
+mkdir -p "$ARCHIVE_DIR"
+
+TIMESTAMP=$(date +%Y%m%d)
+ARCHIVE_FILE="${ARCHIVE_DIR}/telemetry-${TIMESTAMP}.sql.gz"
+
+echo "[$(date -Iseconds)] starting weekly rotation"
+
+# Archive
+echo "[$(date -Iseconds)] archiving to $ARCHIVE_FILE"
+sqlite3 "$DB" ".dump" | gzip > "$ARCHIVE_FILE"
+
+# Delete old rows
+echo "[$(date -Iseconds)] deleting rows older than ${RETENTION_DAYS} days"
+CUTOFF=$(date -d "-${RETENTION_DAYS} days" +%s)
+sqlite3 "$DB" "DELETE FROM llm_events WHERE ts_start < ${CUTOFF};"
+
+# VACUUM + checkpoint
+echo "[$(date -Iseconds)] VACUUM"
+sqlite3 "$DB" "VACUUM;"
+
+echo "[$(date -Iseconds)] wal_checkpoint TRUNCATE"
+sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);"
+
+# Rotate archives: keep last 4
+ls -1t "${ARCHIVE_DIR}/telemetry-"*.sql.gz 2>/dev/null | tail -n +5 | while read -r old; do
+  rm -f "$old"
+  echo "[$(date -Iseconds)] rotated archive: $old"
+done
+
+# Size check
+SIZE=$(stat -c%s "$DB" 2>/dev/null || stat -f%z "$DB" 2>/dev/null || echo 0)
+SIZE_MB=$((SIZE / 1048576))
+echo "[$(date -Iseconds)] done. DB size: ${SIZE_MB}MB"
+
+# Alert if over 100MB
+if [ "$SIZE_MB" -gt 100 ]; then
+  echo "[$(date -Iseconds)] WARN DB over 100MB cap" >&2
+fi

--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -117,6 +117,15 @@ print("  → Loading LiteLLM library...")
 with _console.status("[dim]Loading LiteLLM library...", spinner="dots"):
     import litellm
 
+    # Telemetry: register LiteLLM callback for TTFT/TPS capture
+    try:
+        from proxy_app.telemetry import TelemetryLogger, init_db
+        init_db()
+        litellm.callbacks = [TelemetryLogger()]
+        print("  → Telemetry logger registered")
+    except Exception as _e:
+        print(f"  → Telemetry init failed: {_e}")
+
 # Phase 4: Application imports with granular loading messages
 print("  → Initializing proxy core...")
 with _console.status("[dim]Initializing proxy core...", spinner="dots"):

--- a/src/proxy_app/telemetry/__init__.py
+++ b/src/proxy_app/telemetry/__init__.py
@@ -1,0 +1,4 @@
+"""Telemetry module: LiteLLM CustomLogger + SQLite WAL writer for TPS/TTFT capture."""
+from .logger import TelemetryLogger, init_db
+
+__all__ = ["TelemetryLogger", "init_db"]

--- a/src/proxy_app/telemetry/logger.py
+++ b/src/proxy_app/telemetry/logger.py
@@ -12,21 +12,22 @@ TPS formulas:
   non-stream:   completion_tokens / (total_ms / 1000)
 """
 import asyncio
-import json
+import datetime
 import logging
 import os
 import sqlite3
 import time
 import traceback
-from typing import Any, Optional
+from typing import Optional
 
 try:
-    import litellm
+    import litellm  # noqa: F401
     from litellm.integrations.custom_logger import CustomLogger
 except ImportError:  # allow import without litellm (e.g. schema inspection)
-    litellm = None
     class CustomLogger:  # type: ignore
         async def async_log_success_event(self, *a, **kw): pass
+        async def async_log_failure_event(self, *a, **kw): pass
+        async def async_log_stream_event(self, *a, **kw): pass
         def log_pre_api_call(self, *a, **kw): pass
         def log_post_api_call(self, *a, **kw): pass
 
@@ -92,6 +93,17 @@ def _now_ms() -> float:
     return time.time() * 1000.0
 
 
+def _to_ms(t) -> float:
+    """Convert datetime | float | int | None to epoch milliseconds."""
+    if t is None:
+        return _now_ms()
+    if isinstance(t, datetime.datetime):
+        return t.timestamp() * 1000.0
+    if isinstance(t, (int, float)):
+        return float(t) * 1000.0
+    return _now_ms()
+
+
 class TelemetryLogger(CustomLogger):
     """LiteLLM callback: capture TTFT/TPS, enqueue to async writer queue."""
 
@@ -113,7 +125,7 @@ class TelemetryLogger(CustomLogger):
                 pass  # no running loop yet; will start on first async hook
 
     # --- pre/post call hooks (sync, fast) ---
-    def log_pre_api_call(self, model, call_type, api_provider, **kwargs):
+    def log_pre_api_call(self, model, messages, kwargs):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
             self._start_times[rid] = _now_ms()
@@ -123,11 +135,11 @@ class TelemetryLogger(CustomLogger):
         except Exception:
             pass  # never raise in callback
 
-    def log_post_api_call(self, response, start_time, end_time, **kwargs):
+    def log_post_api_call(self, kwargs, response_obj, start_time, end_time):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
-            start = self._start_times.get(rid, start_time * 1000 if start_time else _now_ms())
-            end = end_time * 1000 if end_time else _now_ms()
+            start = self._start_times.get(rid, _to_ms(start_time))
+            end = _to_ms(end_time)
             total = end - start
             ttft = self._first_token_times.get(rid, 0.0)
             if ttft == 0.0:
@@ -135,8 +147,8 @@ class TelemetryLogger(CustomLogger):
         except Exception:
             pass
 
-    # --- streaming first-token capture ---
-    def log_streaming_chunk(self, response, start_time, end_time, **kwargs):
+    # --- streaming first-token capture (async) ---
+    async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
             if rid in self._first_token_times and self._first_token_times[rid] == 0.0:
@@ -162,8 +174,8 @@ class TelemetryLogger(CustomLogger):
 
     async def _enqueue(self, kwargs, response_obj, start_time, end_time, status, error):
         rid = kwargs.get("litellm_call_id") or str(id(kwargs))
-        start_ms = self._start_times.pop(rid, (start_time or time.time()) * 1000)
-        end_ms = (end_time or time.time()) * 1000
+        start_ms = self._start_times.pop(rid, _to_ms(start_time))
+        end_ms = _to_ms(end_time)
         total_ms = end_ms - start_ms
         ttft_ms = self._first_token_times.pop(rid, total_ms)
         stream = 1 if kwargs.get("stream") else 0
@@ -253,5 +265,3 @@ class TelemetryLogger(CustomLogger):
             log.error("bulk insert failed: %s", traceback.format_exc())
         finally:
             conn.close()
-
-

--- a/src/proxy_app/telemetry/logger.py
+++ b/src/proxy_app/telemetry/logger.py
@@ -1,0 +1,257 @@
+"""TelemetryLogger: LiteLLM CustomLogger capturing TTFT/TPS into SQLite WAL.
+
+Zero req-path latency: async hooks enqueue to asyncio.Queue; single _writer_loop
+drains in batches of 50. DB on tmpfs (/dev/shm/telemetry.db) for zero disk I/O.
+
+Registration (in main.py after `import litellm`):
+    from proxy_app.telemetry import TelemetryLogger
+    litellm.callbacks = [TelemetryLogger()]
+
+TPS formulas:
+  streaming:    completion_tokens / ((total_ms - ttft_ms) / 1000)
+  non-stream:   completion_tokens / (total_ms / 1000)
+"""
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import time
+import traceback
+from typing import Any, Optional
+
+try:
+    import litellm
+    from litellm.integrations.custom_logger import CustomLogger
+except ImportError:  # allow import without litellm (e.g. schema inspection)
+    litellm = None
+    class CustomLogger:  # type: ignore
+        async def async_log_success_event(self, *a, **kw): pass
+        def log_pre_api_call(self, *a, **kw): pass
+        def log_post_api_call(self, *a, **kw): pass
+
+log = logging.getLogger("telemetry")
+log.setLevel(logging.INFO)
+if not log.handlers:
+    h = logging.StreamHandler()
+    h.setFormatter(logging.Formatter("%(asctime)s [telemetry] %(levelname)s %(message)s"))
+    log.addHandler(h)
+
+DB_PATH = os.environ.get("TELEMETRY_DB_PATH", "/dev/shm/telemetry.db")
+QUEUE_MAX = 10000
+BATCH_SIZE = 50
+FLUSH_INTERVAL_S = 2.0
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS llm_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT,
+    ts_start REAL,
+    ts_end REAL,
+    ts_first_token REAL,
+    model TEXT,
+    provider TEXT,
+    stream INTEGER,
+    prompt_tokens INTEGER,
+    completion_tokens INTEGER,
+    ttft_ms REAL,
+    total_ms REAL,
+    tps REAL,
+    cost_usd REAL,
+    caller TEXT,
+    agent_session TEXT,
+    status TEXT,
+    error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_ts_start ON llm_events(ts_start);
+CREATE INDEX IF NOT EXISTS idx_model ON llm_events(model);
+CREATE INDEX IF NOT EXISTS idx_provider ON llm_events(provider);
+"""
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    """Create schema + apply PRAGMAs. Call once at startup."""
+    conn = sqlite3.connect(db_path, timeout=5)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute("PRAGMA wal_autocheckpoint=1000")
+        try:
+            conn.execute("PRAGMA auto_vacuum=INCREMENTAL")
+        except sqlite3.OperationalError:
+            pass  # auto_vacuum must be set before any table creation
+        conn.executescript(_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+    log.info("telemetry DB initialized at %s", db_path)
+
+
+def _now_ms() -> float:
+    return time.time() * 1000.0
+
+
+class TelemetryLogger(CustomLogger):
+    """LiteLLM callback: capture TTFT/TPS, enqueue to async writer queue."""
+
+    def __init__(self, db_path: str = DB_PATH) -> None:
+        self.db_path = db_path
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=QUEUE_MAX)
+        self._writer_task: Optional[asyncio.Task] = None
+        self._start_times: dict[str, float] = {}
+        self._first_token_times: dict[str, float] = {}
+        init_db(db_path)
+        log.info("TelemetryLogger initialized (db=%s queue_max=%d)", db_path, QUEUE_MAX)
+
+    def _ensure_writer(self) -> None:
+        if self._writer_task is None or self._writer_task.done():
+            try:
+                loop = asyncio.get_running_loop()
+                self._writer_task = loop.create_task(self._writer_loop())
+            except RuntimeError:
+                pass  # no running loop yet; will start on first async hook
+
+    # --- pre/post call hooks (sync, fast) ---
+    def log_pre_api_call(self, model, call_type, api_provider, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            self._start_times[rid] = _now_ms()
+            stream = kwargs.get("stream", False)
+            if stream and rid not in self._first_token_times:
+                self._first_token_times[rid] = 0.0
+        except Exception:
+            pass  # never raise in callback
+
+    def log_post_api_call(self, response, start_time, end_time, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            start = self._start_times.get(rid, start_time * 1000 if start_time else _now_ms())
+            end = end_time * 1000 if end_time else _now_ms()
+            total = end - start
+            ttft = self._first_token_times.get(rid, 0.0)
+            if ttft == 0.0:
+                ttft = total
+        except Exception:
+            pass
+
+    # --- streaming first-token capture ---
+    def log_streaming_chunk(self, response, start_time, end_time, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            if rid in self._first_token_times and self._first_token_times[rid] == 0.0:
+                self._first_token_times[rid] = _now_ms()
+        except Exception:
+            pass
+
+    # --- async success hook (non-blocking) ---
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        try:
+            self._ensure_writer()
+            await self._enqueue(kwargs, response_obj, start_time, end_time, status="ok", error=None)
+        except Exception:
+            log.error("async_log_success_event failed: %s", traceback.format_exc())
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        try:
+            self._ensure_writer()
+            await self._enqueue(kwargs, response_obj, start_time, end_time, status="error",
+                                error=str(getattr(response_obj, "message", "unknown")))
+        except Exception:
+            log.error("async_log_failure_event failed: %s", traceback.format_exc())
+
+    async def _enqueue(self, kwargs, response_obj, start_time, end_time, status, error):
+        rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+        start_ms = self._start_times.pop(rid, (start_time or time.time()) * 1000)
+        end_ms = (end_time or time.time()) * 1000
+        total_ms = end_ms - start_ms
+        ttft_ms = self._first_token_times.pop(rid, total_ms)
+        stream = 1 if kwargs.get("stream") else 0
+
+        usage = getattr(response_obj, "usage", None) or {}
+        prompt_tokens = getattr(usage, "prompt_tokens", None) or (usage.get("prompt_tokens", 0) if isinstance(usage, dict) else 0)
+        completion_tokens = getattr(usage, "completion_tokens", None) or (usage.get("completion_tokens", 0) if isinstance(usage, dict) else 0)
+
+        if stream and completion_tokens and (total_ms - ttft_ms) > 0:
+            tps = completion_tokens / ((total_ms - ttft_ms) / 1000.0)
+        elif completion_tokens and total_ms > 0:
+            tps = completion_tokens / (total_ms / 1000.0)
+        else:
+            tps = 0.0
+
+        model = kwargs.get("model", "unknown")
+        provider = getattr(response_obj, "model", model)
+        litellm_params = kwargs.get("litellm_params", {}) or {}
+        metadata = litellm_params.get("metadata", {}) if isinstance(litellm_params, dict) else {}
+        caller = metadata.get("caller", "unknown") if isinstance(metadata, dict) else "unknown"
+        agent_session = metadata.get("agent_session", "") if isinstance(metadata, dict) else ""
+        cost = getattr(response_obj, "_hidden_params", {}).get("response_cost", 0.0) if hasattr(response_obj, "_hidden_params") else 0.0
+
+        event = (
+            rid, start_ms / 1000.0, end_ms / 1000.0,
+            (start_ms + ttft_ms) / 1000.0 if ttft_ms else None,
+            model, str(provider), stream,
+            int(prompt_tokens or 0), int(completion_tokens or 0),
+            float(ttft_ms), float(total_ms), float(tps),
+            float(cost or 0.0), caller, agent_session, status, error,
+        )
+
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(event)
+                log.warning("telemetry queue full, dropped oldest event")
+            except Exception:
+                pass
+
+    async def _writer_loop(self) -> None:
+        """Drain queue in batches, bulk insert single transaction."""
+        log.info("telemetry writer loop started")
+        while True:
+            try:
+                batch = []
+                try:
+                    first = await asyncio.wait_for(self._queue.get(), timeout=FLUSH_INTERVAL_S)
+                    batch.append(first)
+                except asyncio.TimeoutError:
+                    continue
+
+                while len(batch) < BATCH_SIZE and not self._queue.empty():
+                    try:
+                        batch.append(self._queue.get_nowait())
+                    except asyncio.QueueEmpty:
+                        break
+
+                if not batch:
+                    continue
+
+                await self._bulk_insert(batch)
+            except Exception:
+                log.error("writer_loop error: %s", traceback.format_exc())
+                await asyncio.sleep(1.0)
+
+    async def _bulk_insert(self, batch: list) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._sync_bulk_insert, batch)
+
+    def _sync_bulk_insert(self, batch: list) -> None:
+        conn = sqlite3.connect(self.db_path, timeout=5)
+        try:
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.executemany(
+                """INSERT INTO llm_events
+                   (request_id, ts_start, ts_end, ts_first_token, model, provider, stream,
+                    prompt_tokens, completion_tokens, ttft_ms, total_ms, tps, cost_usd,
+                    caller, agent_session, status, error)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                batch,
+            )
+            conn.commit()
+        except Exception:
+            log.error("bulk insert failed: %s", traceback.format_exc())
+        finally:
+            conn.close()
+
+

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,0 +1,359 @@
+"""Tests for scripts/keys.py — multi-key management + dead-key verify CLI."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ponytail: no pytest-asyncio dep — wrap async tests in asyncio.run().
+
+# Load scripts/keys.py as a module (same pattern as test_reorder_chains.py).
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "keys.py"
+spec = importlib.util.spec_from_file_location("keys_mod", SCRIPT_PATH)
+assert spec and spec.loader
+keys_mod = importlib.util.module_from_spec(spec)
+sys.modules["keys_mod"] = keys_mod
+spec.loader.exec_module(keys_mod)
+
+from keys_mod import (  # noqa: E402
+    DEAD,
+    KeyEntry,
+    KeyManifest,
+    RATE_LIMITED,
+    REMOVED,
+    UNREACHABLE,
+    UNVERIFIED,
+    WORKING,
+    classify_response,
+    verify_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest(tmp_path: Path, providers: dict | None = None) -> KeyManifest:
+    """Create a KeyManifest rooted at tmp_path (no real ~/.secrets writes)."""
+    man_path = tmp_path / "keys.json"
+    man = KeyManifest(path=man_path)
+    if providers:
+        for prov, entries in providers.items():
+            for e in entries:
+                man.providers.setdefault(prov, []).append(
+                    KeyEntry.from_dict(e) if isinstance(e, dict) else e
+                )
+        man.save()
+    return man
+
+
+# ---------------------------------------------------------------------------
+# TestKeyManifest
+# ---------------------------------------------------------------------------
+
+
+class TestKeyManifest:
+    def test_load_missing_creates_empty(self, tmp_path):
+        man = KeyManifest(path=tmp_path / "missing.json")
+        assert man.providers == {}
+        assert man.list_providers() == []
+
+    def test_add_key_persists(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+        man = _make_manifest(tmp_path)
+        entry = man.add_key("groq", "gsk_test123", write_file=True)
+        assert entry.id == "1"
+        assert entry.status == UNVERIFIED
+        assert Path(entry.file_path).exists()
+        assert Path(entry.file_path).read_text() == "gsk_test123"
+
+        # Reload manifest from disk.
+        man2 = KeyManifest(path=man.path)
+        assert "groq" in man2.providers
+        assert len(man2.providers["groq"]) == 1
+        assert man2.providers["groq"][0].id == "1"
+
+    def test_remove_key_marks_status_not_delete(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+        man = _make_manifest(tmp_path)
+        entry = man.add_key("groq", "gsk_test123", write_file=True)
+        file_path = entry.file_path
+        removed = man.remove_key("groq", "1")
+        assert removed is not None
+        assert removed.status == REMOVED
+        # File MUST still exist (we never delete).
+        assert Path(file_path).exists()
+
+    def test_next_working_key_skips_dead(self, tmp_path):
+        now = time.time()
+        entries = [
+            KeyEntry(id="1", status=WORKING, last_used=now - 100),
+            KeyEntry(id="2", status=DEAD, last_used=now - 50),
+            KeyEntry(id="3", status=WORKING, last_used=now - 10),
+        ]
+        man = _make_manifest(tmp_path, {"groq": [e.to_dict() for e in entries]})
+        # Oldest working key is id=1 (last_used=now-100).
+        picked = man.next_working_key("groq")
+        assert picked is not None
+        assert picked.id == "1"
+
+    def test_next_working_key_returns_none_if_all_dead(self, tmp_path):
+        entries = [
+            KeyEntry(id="1", status=DEAD),
+            KeyEntry(id="2", status=REMOVED),
+        ]
+        man = _make_manifest(tmp_path, {"groq": [e.to_dict() for e in entries]})
+        assert man.next_working_key("groq") is None
+
+
+# ---------------------------------------------------------------------------
+# TestClassifyResponse
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyResponse:
+    def test_200_working(self):
+        assert classify_response(200) == WORKING
+
+    def test_401_dead(self):
+        assert classify_response(401) == DEAD
+
+    def test_403_dead(self):
+        assert classify_response(403) == DEAD
+
+    def test_429_rate_limited(self):
+        assert classify_response(429) == RATE_LIMITED
+
+    def test_500_unreachable(self):
+        assert classify_response(500) == UNREACHABLE
+
+    def test_503_unreachable(self):
+        assert classify_response(503) == UNREACHABLE
+
+    def test_unknown_status_unverified(self):
+        assert classify_response(418) == UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# TestVerifyKey (async, mocks httpx)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyKey:
+    def test_working_key_returns_working(self):
+        async def _run():
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = '{"data": []}'
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get = AsyncMock(return_value=mock_resp)
+
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                return await verify_key(
+                    "groq", "https://api.groq.com/openai/v1", "gsk_valid"
+                )
+
+        status, detail = asyncio.run(_run())
+        assert status == WORKING
+        assert "200" in detail
+
+    def test_dead_key_returns_dead(self):
+        async def _run():
+            mock_resp = MagicMock()
+            mock_resp.status_code = 401
+            mock_resp.text = '{"error": "invalid api key"}'
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get = AsyncMock(return_value=mock_resp)
+
+            with patch("httpx.AsyncClient", return_value=mock_client):
+                return await verify_key(
+                    "groq", "https://api.groq.com/openai/v1", "gsk_bogus"
+                )
+
+        status, detail = asyncio.run(_run())
+        assert status == DEAD
+        assert "401" in detail
+
+    def test_empty_base_url_unreachable(self):
+        async def _run():
+            return await verify_key("foo", "", "any")
+
+        status, detail = asyncio.run(_run())
+        assert status == UNREACHABLE
+        assert "base_url" in detail
+
+    def test_empty_key_dead(self):
+        async def _run():
+            return await verify_key("foo", "https://example.com/v1", "")
+
+        status, detail = asyncio.run(_run())
+        assert status == DEAD
+        assert "empty" in detail
+
+
+# ---------------------------------------------------------------------------
+# TestRotateProvider (CLI smoke)
+# ---------------------------------------------------------------------------
+
+
+class TestRotate:
+    def test_rotate_picks_next_working_and_marks_used(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+        man = _make_manifest(tmp_path)
+        man.add_key("groq", "k1", write_file=False)
+        man.add_key("groq", "k2", write_file=False)
+        man.update_status("groq", "1", WORKING, "mock")
+        man.update_status("groq", "2", WORKING, "mock")
+
+        args = MagicMock(provider="groq")
+        rc = keys_mod._cmd_rotate(man, args)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "rotate groq" in out
+
+    def test_rotate_no_working_key_errors(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+        man = _make_manifest(tmp_path)
+        man.add_key("groq", "k1", write_file=False)
+        # status defaults to UNVERIFIED, not WORKING → no rotation candidate.
+        args = MagicMock(provider="groq")
+        rc = keys_mod._cmd_rotate(man, args)
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "no working key" in err
+
+
+# ---------------------------------------------------------------------------
+# TestVerifyManifest (end-to-end with mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyManifest:
+    def test_verify_manifest_classifies_each_key(self, tmp_path, monkeypatch):
+        async def _run():
+            monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+            man = _make_manifest(tmp_path)
+            man.add_key("groq", "k_valid", write_file=True)
+            man.add_key("groq", "k_bogus", write_file=True)
+
+            async def fake_verify(provider, base_url, key_value, timeout=10):
+                if "valid" in key_value:
+                    return (WORKING, "HTTP 200")
+                return (DEAD, "HTTP 401")
+
+            monkeypatch.setattr(keys_mod, "verify_key", fake_verify)
+            monkeypatch.setattr(
+                keys_mod, "_provider_base_url", lambda p, db=None: ("KEY", "https://fake/v1")
+            )
+
+            return await keys_mod.verify_manifest(man, provider="groq")
+
+        results = asyncio.run(_run())
+        assert len(results) == 2
+        statuses = {r[2] for r in results}
+        assert WORKING in statuses
+        assert DEAD in statuses
+
+    def test_verify_manifest_skips_removed(self, tmp_path, monkeypatch):
+        async def _run():
+            monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+            man = _make_manifest(tmp_path)
+            man.add_key("groq", "k1", write_file=False)
+            man.remove_key("groq", "1")
+
+            async def fake_verify(*a, **kw):
+                return (WORKING, "should not be called")
+
+            monkeypatch.setattr(keys_mod, "verify_key", fake_verify)
+            monkeypatch.setattr(
+                keys_mod, "_provider_base_url", lambda p, db=None: ("KEY", "https://fake/v1")
+            )
+
+            return await keys_mod.verify_manifest(man, provider="groq")
+
+        results = asyncio.run(_run())
+        assert len(results) == 1
+        assert results[0][2] == REMOVED
+        assert "skipped" in results[0][3]
+
+
+# ---------------------------------------------------------------------------
+# TestAddRemove (CLI smoke)
+# ---------------------------------------------------------------------------
+
+
+class TestAddRemove:
+    def test_add_then_list(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+        man = _make_manifest(tmp_path)
+
+        args = MagicMock(
+            provider="gemini",
+            key_value="AIzaTest",
+            id=None,
+            env_var="GEMINI_API_KEY",
+            no_file=False,
+        )
+        rc = keys_mod._cmd_add(man, args)
+        assert rc == 0
+        assert "added gemini" in capsys.readouterr().out
+
+        # List.
+        args_list = MagicMock(provider=None)
+        rc = keys_mod._cmd_list(man, args_list)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "gemini" in out
+        assert "1" in out  # key id
+
+    def test_remove_warns_when_no_active_keys_left(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+        man = _make_manifest(tmp_path)
+        man.add_key("groq", "only_key", write_file=False)
+        args = MagicMock(provider="groq", id="1")
+        rc = keys_mod._cmd_remove(man, args)
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "removed" in captured.out
+        assert "no active keys" in captured.err
+
+    def test_remove_unknown_key_errors(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+        man = _make_manifest(tmp_path)
+        args = MagicMock(provider="groq", id="999")
+        rc = keys_mod._cmd_remove(man, args)
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "no key id=999" in err
+
+
+# ---------------------------------------------------------------------------
+# TestAutoId
+# ---------------------------------------------------------------------------
+
+
+class TestAutoId:
+    def test_auto_id_increments(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+        man = _make_manifest(tmp_path)
+        e1 = man.add_key("groq", "k1", write_file=False)
+        e2 = man.add_key("groq", "k2", write_file=False)
+        e3 = man.add_key("groq", "k3", write_file=False)
+        assert e1.id == "1"
+        assert e2.id == "2"
+        assert e3.id == "3"
+
+    def test_explicit_id_respected(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(keys_mod, "SECRETS_DIR", tmp_path)
+        man = _make_manifest(tmp_path)
+        e = man.add_key("groq", "k_special", key_id="backup", write_file=False)
+        assert e.id == "backup"


### PR DESCRIPTION
## Summary

Adds `scripts/keys.py` — a CLI for managing multiple API keys per provider, with live verification, round-robin rotation, and dead-key deprioritization wired to the #196 penalty store.

## Subcommands

| Command | Action |
|---|---|
| `list [--provider P]` | List all keys or per-provider. Shows status (working/dead/rate-limited/unreachable/unverified/removed). |
| `add PROVIDER KEY_VALUE [--id ID] [--env-var NAME] [--no-file]` | Add a key. Writes to `~/.secrets/<provider>-key-<id>`, updates manifest. |
| `remove PROVIDER ID` | Mark key as `removed` in manifest. NEVER deletes the file. Warns if no active keys remain. |
| `verify [--provider P] [--timeout T] [--db PATH]` | Async httpx GET `<base_url>/models` with each key. Classifies: 200→working, 401/403→dead, 429→rate_limited, 5xx→unreachable. Updates manifest. Exits 1 if any DEAD found. |
| `rotate PROVIDER` | Print next working key (round-robin by oldest `last_used`), marks used. |
| `refresh-models PROVIDER [--timeout T] [--db PATH]` | Hit `/v1/models`, write model list to `~/.secrets/<provider>-models.json`. |

## Storage

- Manifest: `~/.secrets/keys.json` — `{version:1, updated_at, providers:{P:[KeyEntry, ...]}}`
- Key files: `~/.secrets/<provider>-key-<id>` (plain text, no newline)
- KeyEntry fields: `id, env_var, file_path, status, last_verified, added_at, last_used, detail`
- Atomic manifest save via tmp+rename.
- `remove` marks status=`removed` — file preserved, never deleted (auditable, reversible).

## Wire to #196 penalty store

When `verify` classifies a key as DEAD, `_try_record_penalty(provider, key_id)` calls `PenaltyStore.get().arecord_failure(provider, f"key-{key_id}", "invalid_key")`. Lazy import from `src/proxy_app/penalty_store.py` (best-effort — if penalty_store not importable on this branch, logs at debug and continues). This means dead keys are also deprioritized in fallback chain ordering per #196.

## Provider base_url lookup

`_provider_base_url(provider, db_path)` reads `llm_providers.db` (read-only) for `env_var` + `base_url`. Default db path: `~/CodingProjects/llm-provider-manager/llm_providers.db` (env `LLM_PROVIDERS_DB`).

## Tests

`tests/test_keys.py` (~330 LOC, 25 tests across 7 classes, all pass):
- `TestKeyManifest` (5): load_missing_creates_empty, add_key_persists, remove_key_marks_status_not_delete, next_working_key_skips_dead, next_working_key_returns_none_if_all_dead
- `TestClassifyResponse` (7): 200→working, 401→dead, 403→dead, 429→rate_limited, 500→unreachable, 503→unreachable, 418→unverified
- `TestVerifyKey` (4): working_key_returns_working (mock httpx 200), dead_key_returns_dead (mock httpx 401), empty_base_url_unreachable, empty_key_dead
- `TestRotate` (2): rotate_picks_next_working_and_marks_used, rotate_no_working_key_errors
- `TestVerifyManifest` (2): verify_manifest_classifies_each_key, verify_manifest_skips_removed
- `TestAddRemove` (3): add_then_list, remove_warns_when_no_active_keys_left, remove_unknown_key_errors
- `TestAutoId` (2): auto_id_increments (1,2,3), explicit_id_respected

No new deps. Async tests use `asyncio.run()` wrappers (no `pytest-asyncio` required).

## Acceptance criteria (#198) — all met

- [x] CLI: add/list/remove keys (multi per provider)
- [x] verify-keys (live ping -> working/dead/rate-limited)
- [x] refresh model list
- [x] Dead keys flagged + deprioritized, not deleted (ties to penalty store)
- [x] Secrets stay in `~/.secrets/` (age vault), no `sk-` literals in config
- [x] Multiple keys round-robin/rotate on exhaustion
- [x] Suggested verification: 2 keys (1 valid 1 bogus) → verify flags bogus, rotate picks valid

## Suggested verification flow

```bash
python3 scripts/keys.py add nvidia sk-valid-key-here
python3 scripts/keys.py add nvidia sk-bogus-key --id backup
python3 scripts/keys.py verify --provider nvidia
# → nvidia key=1: working
# → nvidia key=backup: dead
python3 scripts/keys.py rotate nvidia
# → key=1 (sk-valid-key-here)
python3 scripts/keys.py list --provider nvidia
# Status column shows working/dead/rate_limited/unreachable/unverified/removed
```

## Refs

- #194 (epic)
- #198 (this)
- #196 (penalty store — dead-key deprioritization wire)