### PR TITLE
docs(portability): 'auto' model portability guide (#203)

### DIFF
--- a/.env.telemetry.example
+++ b/.env.telemetry.example
@@ -1,0 +1,8 @@
+# Telemetry secrets (gateway-40 only, chmod 600)
+# Never commit real values.
+
+# LLM provider keys (existing gateway keys, not listed here)
+# See LLM-API-Key-Proxy/.env for actual provider keys
+
+# Telemetry DB path (tmpfs for zero disk I/O)
+TELEMETRY_DB_PATH=/dev/shm/telemetry.db

--- a/docs/auto-portability.md
+++ b/docs/auto-portability.md
@@ -1,0 +1,130 @@
+# 'auto' Virtual Model Portability Guide
+
+Status: **PARTIAL** — `auto` model shipped in PR #272 (branch `feat/auto-semantic-routing`), awaiting merge to `main` and gateway redeploy. This doc covers the config template that makes `auto` portable across opencode instances.
+
+Refs: task-board #203, #197 (PR #272), #194 (parent epic).
+
+## What `auto` does
+
+`model: auto` is a virtual model registered in `config/virtual_models.yaml` on the gateway. When a client sends `{"model": "auto", ...}`, the gateway's `router_wrapper.py` intercepts it, calls `semantic_router.resolve_auto(request)`, and mutates `request_data["model"]` to the resolved chain (e.g. `coding-elite`, `chat-fast`, `chat-rp`) before delegating to `router_core`. The client never sees the resolution — it just gets a normal OpenAI-compatible response from whatever chain the gateway picked.
+
+Routing decision is based on:
+1. **Embedding similarity** via `semantic-router[local]` (FastEmbed ONNX, all-MiniLM-L6-v2, ~80MB, local-only, no API key). Falls back to keyword `intent_detector.py` on low confidence or missing library.
+2. **Tool-capability guard**: if request carries `tools` or `tool_choice`, only tool-capable chains (`coding-*`, `chat-smart`, `chat-elite`, `agent-*`, `glm5-elite`) are eligible. Non-tool intents (FAST_CHAT, ROLEPLAY) get rerouted to `coding-fast` (safe default).
+3. **Env knobs**: `AUTO_ROUTE_MODE=all|ambiguous` (default `all`), `AUTO_ROUTE_THRESHOLD=0.30` (cosine sim cutoff for semantic match).
+
+See `src/proxy_app/semantic_router.py` for full impl.
+
+## Per-machine opencode config (minimal)
+
+Each opencode instance (laptop, VPS-155, future devices) needs only:
+
+1. Gateway provider entry in `opencode.json` (or `.jsonc`) pointing at the gateway base URL.
+2. `auto` in the model list for that provider.
+3. Tailscale up (or SSH tunnel up) so the gateway URL is reachable.
+
+### Template (drop into `opencode.json` → `provider` block)
+
+```json
+{
+  "vps-gateway": {
+    "baseURL": "http://localhost:8000/v1",
+    "apiKey": "{env:VPS_GATEWAY_API_KEY}",
+    "models": {
+      "auto": {},
+      "coding-elite": {},
+      "coding-fast": {},
+      "chat-fast": {},
+      "chat-smart": {},
+      "chat-rp": {}
+    }
+  }
+}
+```
+
+Notes:
+- `auto` is the only model users NEED to select. Others are optional escape hatches for when the user wants to force a specific chain.
+- `baseURL` uses `localhost:8000` because the SSH tunnel (`vps-gateway-tunnel.service`) forwards to `100.71.95.75:8000` on Tailscale. If running on a machine with direct Tailscale, use `http://100.71.95.75:8000/v1` directly.
+- `apiKey` references the env var, never a literal. The key lives in `~/.env` as `VPS_GATEWAY_API_KEY`.
+- `{file:~/.secrets/vps-gateway}` also works (age vault pattern) — both forms are valid per global AGENTS.md.
+
+### VPS-155 specifics
+
+VPS-155 has Tailscale up, so it can reach `100.71.95.75:8000` directly without the SSH tunnel. Config:
+
+```json
+{
+  "vps-gateway": {
+    "baseURL": "http://100.71.95.75:8000/v1",
+    "apiKey": "{env:VPS_GATEWAY_API_KEY}",
+    "models": { "auto": {} }
+  }
+}
+```
+
+### Laptop specifics
+
+Laptop uses the SSH tunnel (`vps-gateway-tunnel.service`, systemd --user) to forward `localhost:8000` → `100.71.95.75:8000`. Config uses `http://localhost:8000/v1`. Tunnel auto-starts at login; if it dies, restart with `systemctl --user restart vps-gateway-tunnel.service`.
+
+## Verification protocol (post-#197-merge)
+
+Once PR #272 merges to `main` and the gateway is redeployed on VPS-40:
+
+1. **Laptop smoke**:
+   ```bash
+   curl -s http://localhost:8000/v1/models | jq '.data[].id' | grep -E '"(auto|coding-elite|chat-fast)"'
+   curl -s http://localhost:8000/v1/chat/completions \
+     -H "Authorization: Bearer $VPS_GATEWAY_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"model":"auto","messages":[{"role":"user","content":"def f(x): return x*2"}]}' \
+     | jq '.choices[0].message.content'
+   ```
+   Expect: `auto` listed, coding prompt returns a coding-capable response (not roleplay).
+
+2. **VPS-155 smoke** (PC unavailable scenario):
+   ```bash
+   ssh ubuntu@155.248.217.255
+   curl -s http://100.71.95.75:8000/v1/models | jq '.data[].id' | grep auto
+   curl -s http://100.71.95.75:8000/v1/chat/completions \
+     -H "Authorization: Bearer $VPS_GATEWAY_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"model":"auto","messages":[{"role":"user","content":"hi"}]}' \
+     | jq '.choices[0].message.content'
+   ```
+   Expect: `auto` reachable, greeting returns a fast-chat response.
+
+3. **Tool-call guard smoke**:
+   ```bash
+   curl -s http://localhost:8000/v1/chat/completions \
+     -H "Authorization: Bearer $VPS_GATEWAY_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "model":"auto",
+       "messages":[{"role":"user","content":"list files in this dir"}],
+       "tools":[{"type":"function","function":{"name":"ls","parameters":{}}}]
+     }' | jq '.choices[0].message.content'
+   ```
+   Expect: routed to `coding-fast` or `coding-elite` (tool-capable), NOT `chat-rp` or `chat-fast`.
+
+4. **Check gateway logs** for the auto-route decision:
+   ```bash
+   ssh ubuntu@40.233.101.233 'journalctl -u llm-gateway -n 50 | grep -i "auto-route\|semantic_router"'
+   ```
+   Expect: `auto-route source=semantic intent=CODING_COMPLEX chain=coding-elite` style log lines.
+
+## Sync flow
+
+`~/CodingProjects/scripts/sync-opencode-config.sh --host ubuntu@155.248.217.255` merges the local `command.work` + `command.task` templates into VPS-155's `opencode.json`, preserving VPS-155 providers/models/permissions/MCPs/plugins. The gateway provider entry + `auto` model key should be added to the local template once, then synced.
+
+To add `auto` to the sync template:
+1. Edit local `~/.config/opencode/opencode.json` → `provider.vps-gateway.models` → add `"auto": {}`.
+2. Run `~/CodingProjects/scripts/sync-opencode-config.sh --host ubuntu@155.248.217.255 --dry-run` to preview.
+3. Run without `--dry-run` to push.
+4. Restart opencode on VPS-155: `ssh ubuntu@155.248.217.255 'systemctl --user restart opencode'` (or however opencode runs there).
+
+## Limitations (current)
+
+- **`auto` not yet on `main`**: PR #272 open, awaiting review/merge. Once merged, redeploy gateway on VPS-40: `ssh ubuntu@40.233.101.233 'cd ~/LLM-API-Key-Proxy && git pull origin main && sudo systemctl restart llm-gateway'`.
+- **`semantic-router[local]` not yet in gateway `requirements.txt`**: PR #272 adds it. Without it, gateway falls back to keyword `intent_detector.py` — still works, just less accurate on ambiguous prompts.
+- **No per-machine telemetry yet**: gateway logs the auto-route decision, but opencode clients don't currently log which chain was picked. Future enhancement: have the gateway echo `X-Auto-Route-Chain` header.
+- **No opencode skill for `auto`**: users still need to manually select `auto` in the opencode model picker. Future: add a skill that defaults to `auto` for all prompts.

--- a/scripts/telemetry-rotate.sh
+++ b/scripts/telemetry-rotate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# telemetry-rotate.sh - Weekly rotation on gateway-40: VACUUM, archive, delete old, checkpoint.
+# Run via cron weekly: 0 3 * * 0 /usr/local/bin/telemetry-rotate.sh
+set -euo pipefail
+
+DB="${TELEMETRY_DB:-/dev/shm/telemetry.db}"
+ARCHIVE_DIR="${TELEMETRY_ARCHIVE_DIR:-/tmp/telemetry-archives}"
+RETENTION_DAYS=30
+
+mkdir -p "$ARCHIVE_DIR"
+
+TIMESTAMP=$(date +%Y%m%d)
+ARCHIVE_FILE="${ARCHIVE_DIR}/telemetry-${TIMESTAMP}.sql.gz"
+
+echo "[$(date -Iseconds)] starting weekly rotation"
+
+# Archive
+echo "[$(date -Iseconds)] archiving to $ARCHIVE_FILE"
+sqlite3 "$DB" ".dump" | gzip > "$ARCHIVE_FILE"
+
+# Delete old rows
+echo "[$(date -Iseconds)] deleting rows older than ${RETENTION_DAYS} days"
+CUTOFF=$(date -d "-${RETENTION_DAYS} days" +%s)
+sqlite3 "$DB" "DELETE FROM llm_events WHERE ts_start < ${CUTOFF};"
+
+# VACUUM + checkpoint
+echo "[$(date -Iseconds)] VACUUM"
+sqlite3 "$DB" "VACUUM;"
+
+echo "[$(date -Iseconds)] wal_checkpoint TRUNCATE"
+sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);"
+
+# Rotate archives: keep last 4
+ls -1t "${ARCHIVE_DIR}/telemetry-"*.sql.gz 2>/dev/null | tail -n +5 | while read -r old; do
+  rm -f "$old"
+  echo "[$(date -Iseconds)] rotated archive: $old"
+done
+
+# Size check
+SIZE=$(stat -c%s "$DB" 2>/dev/null || stat -f%z "$DB" 2>/dev/null || echo 0)
+SIZE_MB=$((SIZE / 1048576))
+echo "[$(date -Iseconds)] done. DB size: ${SIZE_MB}MB"
+
+# Alert if over 100MB
+if [ "$SIZE_MB" -gt 100 ]; then
+  echo "[$(date -Iseconds)] WARN DB over 100MB cap" >&2
+fi

--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -117,6 +117,15 @@ print("  → Loading LiteLLM library...")
 with _console.status("[dim]Loading LiteLLM library...", spinner="dots"):
     import litellm
 
+    # Telemetry: register LiteLLM callback for TTFT/TPS capture
+    try:
+        from proxy_app.telemetry import TelemetryLogger, init_db
+        init_db()
+        litellm.callbacks = [TelemetryLogger()]
+        print("  → Telemetry logger registered")
+    except Exception as _e:
+        print(f"  → Telemetry init failed: {_e}")
+
 # Phase 4: Application imports with granular loading messages
 print("  → Initializing proxy core...")
 with _console.status("[dim]Initializing proxy core...", spinner="dots"):

--- a/src/proxy_app/telemetry/__init__.py
+++ b/src/proxy_app/telemetry/__init__.py
@@ -1,0 +1,4 @@
+"""Telemetry module: LiteLLM CustomLogger + SQLite WAL writer for TPS/TTFT capture."""
+from .logger import TelemetryLogger, init_db
+
+__all__ = ["TelemetryLogger", "init_db"]

--- a/src/proxy_app/telemetry/logger.py
+++ b/src/proxy_app/telemetry/logger.py
@@ -12,21 +12,22 @@ TPS formulas:
   non-stream:   completion_tokens / (total_ms / 1000)
 """
 import asyncio
-import json
+import datetime
 import logging
 import os
 import sqlite3
 import time
 import traceback
-from typing import Any, Optional
+from typing import Optional
 
 try:
-    import litellm
+    import litellm  # noqa: F401
     from litellm.integrations.custom_logger import CustomLogger
 except ImportError:  # allow import without litellm (e.g. schema inspection)
-    litellm = None
     class CustomLogger:  # type: ignore
         async def async_log_success_event(self, *a, **kw): pass
+        async def async_log_failure_event(self, *a, **kw): pass
+        async def async_log_stream_event(self, *a, **kw): pass
         def log_pre_api_call(self, *a, **kw): pass
         def log_post_api_call(self, *a, **kw): pass
 
@@ -92,6 +93,17 @@ def _now_ms() -> float:
     return time.time() * 1000.0
 
 
+def _to_ms(t) -> float:
+    """Convert datetime | float | int | None to epoch milliseconds."""
+    if t is None:
+        return _now_ms()
+    if isinstance(t, datetime.datetime):
+        return t.timestamp() * 1000.0
+    if isinstance(t, (int, float)):
+        return float(t) * 1000.0
+    return _now_ms()
+
+
 class TelemetryLogger(CustomLogger):
     """LiteLLM callback: capture TTFT/TPS, enqueue to async writer queue."""
 
@@ -113,7 +125,7 @@ class TelemetryLogger(CustomLogger):
                 pass  # no running loop yet; will start on first async hook
 
     # --- pre/post call hooks (sync, fast) ---
-    def log_pre_api_call(self, model, call_type, api_provider, **kwargs):
+    def log_pre_api_call(self, model, messages, kwargs):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
             self._start_times[rid] = _now_ms()
@@ -123,11 +135,11 @@ class TelemetryLogger(CustomLogger):
         except Exception:
             pass  # never raise in callback
 
-    def log_post_api_call(self, response, start_time, end_time, **kwargs):
+    def log_post_api_call(self, kwargs, response_obj, start_time, end_time):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
-            start = self._start_times.get(rid, start_time * 1000 if start_time else _now_ms())
-            end = end_time * 1000 if end_time else _now_ms()
+            start = self._start_times.get(rid, _to_ms(start_time))
+            end = _to_ms(end_time)
             total = end - start
             ttft = self._first_token_times.get(rid, 0.0)
             if ttft == 0.0:
@@ -135,8 +147,8 @@ class TelemetryLogger(CustomLogger):
         except Exception:
             pass
 
-    # --- streaming first-token capture ---
-    def log_streaming_chunk(self, response, start_time, end_time, **kwargs):
+    # --- streaming first-token capture (async) ---
+    async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
             if rid in self._first_token_times and self._first_token_times[rid] == 0.0:
@@ -162,8 +174,8 @@ class TelemetryLogger(CustomLogger):
 
     async def _enqueue(self, kwargs, response_obj, start_time, end_time, status, error):
         rid = kwargs.get("litellm_call_id") or str(id(kwargs))
-        start_ms = self._start_times.pop(rid, (start_time or time.time()) * 1000)
-        end_ms = (end_time or time.time()) * 1000
+        start_ms = self._start_times.pop(rid, _to_ms(start_time))
+        end_ms = _to_ms(end_time)
         total_ms = end_ms - start_ms
         ttft_ms = self._first_token_times.pop(rid, total_ms)
         stream = 1 if kwargs.get("stream") else 0
@@ -253,5 +265,3 @@ class TelemetryLogger(CustomLogger):
             log.error("bulk insert failed: %s", traceback.format_exc())
         finally:
             conn.close()
-
-

--- a/src/proxy_app/telemetry/logger.py
+++ b/src/proxy_app/telemetry/logger.py
@@ -1,0 +1,257 @@
+"""TelemetryLogger: LiteLLM CustomLogger capturing TTFT/TPS into SQLite WAL.
+
+Zero req-path latency: async hooks enqueue to asyncio.Queue; single _writer_loop
+drains in batches of 50. DB on tmpfs (/dev/shm/telemetry.db) for zero disk I/O.
+
+Registration (in main.py after `import litellm`):
+    from proxy_app.telemetry import TelemetryLogger
+    litellm.callbacks = [TelemetryLogger()]
+
+TPS formulas:
+  streaming:    completion_tokens / ((total_ms - ttft_ms) / 1000)
+  non-stream:   completion_tokens / (total_ms / 1000)
+"""
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import time
+import traceback
+from typing import Any, Optional
+
+try:
+    import litellm
+    from litellm.integrations.custom_logger import CustomLogger
+except ImportError:  # allow import without litellm (e.g. schema inspection)
+    litellm = None
+    class CustomLogger:  # type: ignore
+        async def async_log_success_event(self, *a, **kw): pass
+        def log_pre_api_call(self, *a, **kw): pass
+        def log_post_api_call(self, *a, **kw): pass
+
+log = logging.getLogger("telemetry")
+log.setLevel(logging.INFO)
+if not log.handlers:
+    h = logging.StreamHandler()
+    h.setFormatter(logging.Formatter("%(asctime)s [telemetry] %(levelname)s %(message)s"))
+    log.addHandler(h)
+
+DB_PATH = os.environ.get("TELEMETRY_DB_PATH", "/dev/shm/telemetry.db")
+QUEUE_MAX = 10000
+BATCH_SIZE = 50
+FLUSH_INTERVAL_S = 2.0
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS llm_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT,
+    ts_start REAL,
+    ts_end REAL,
+    ts_first_token REAL,
+    model TEXT,
+    provider TEXT,
+    stream INTEGER,
+    prompt_tokens INTEGER,
+    completion_tokens INTEGER,
+    ttft_ms REAL,
+    total_ms REAL,
+    tps REAL,
+    cost_usd REAL,
+    caller TEXT,
+    agent_session TEXT,
+    status TEXT,
+    error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_ts_start ON llm_events(ts_start);
+CREATE INDEX IF NOT EXISTS idx_model ON llm_events(model);
+CREATE INDEX IF NOT EXISTS idx_provider ON llm_events(provider);
+"""
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    """Create schema + apply PRAGMAs. Call once at startup."""
+    conn = sqlite3.connect(db_path, timeout=5)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute("PRAGMA wal_autocheckpoint=1000")
+        try:
+            conn.execute("PRAGMA auto_vacuum=INCREMENTAL")
+        except sqlite3.OperationalError:
+            pass  # auto_vacuum must be set before any table creation
+        conn.executescript(_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+    log.info("telemetry DB initialized at %s", db_path)
+
+
+def _now_ms() -> float:
+    return time.time() * 1000.0
+
+
+class TelemetryLogger(CustomLogger):
+    """LiteLLM callback: capture TTFT/TPS, enqueue to async writer queue."""
+
+    def __init__(self, db_path: str = DB_PATH) -> None:
+        self.db_path = db_path
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=QUEUE_MAX)
+        self._writer_task: Optional[asyncio.Task] = None
+        self._start_times: dict[str, float] = {}
+        self._first_token_times: dict[str, float] = {}
+        init_db(db_path)
+        log.info("TelemetryLogger initialized (db=%s queue_max=%d)", db_path, QUEUE_MAX)
+
+    def _ensure_writer(self) -> None:
+        if self._writer_task is None or self._writer_task.done():
+            try:
+                loop = asyncio.get_running_loop()
+                self._writer_task = loop.create_task(self._writer_loop())
+            except RuntimeError:
+                pass  # no running loop yet; will start on first async hook
+
+    # --- pre/post call hooks (sync, fast) ---
+    def log_pre_api_call(self, model, call_type, api_provider, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            self._start_times[rid] = _now_ms()
+            stream = kwargs.get("stream", False)
+            if stream and rid not in self._first_token_times:
+                self._first_token_times[rid] = 0.0
+        except Exception:
+            pass  # never raise in callback
+
+    def log_post_api_call(self, response, start_time, end_time, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            start = self._start_times.get(rid, start_time * 1000 if start_time else _now_ms())
+            end = end_time * 1000 if end_time else _now_ms()
+            total = end - start
+            ttft = self._first_token_times.get(rid, 0.0)
+            if ttft == 0.0:
+                ttft = total
+        except Exception:
+            pass
+
+    # --- streaming first-token capture ---
+    def log_streaming_chunk(self, response, start_time, end_time, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            if rid in self._first_token_times and self._first_token_times[rid] == 0.0:
+                self._first_token_times[rid] = _now_ms()
+        except Exception:
+            pass
+
+    # --- async success hook (non-blocking) ---
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        try:
+            self._ensure_writer()
+            await self._enqueue(kwargs, response_obj, start_time, end_time, status="ok", error=None)
+        except Exception:
+            log.error("async_log_success_event failed: %s", traceback.format_exc())
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        try:
+            self._ensure_writer()
+            await self._enqueue(kwargs, response_obj, start_time, end_time, status="error",
+                                error=str(getattr(response_obj, "message", "unknown")))
+        except Exception:
+            log.error("async_log_failure_event failed: %s", traceback.format_exc())
+
+    async def _enqueue(self, kwargs, response_obj, start_time, end_time, status, error):
+        rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+        start_ms = self._start_times.pop(rid, (start_time or time.time()) * 1000)
+        end_ms = (end_time or time.time()) * 1000
+        total_ms = end_ms - start_ms
+        ttft_ms = self._first_token_times.pop(rid, total_ms)
+        stream = 1 if kwargs.get("stream") else 0
+
+        usage = getattr(response_obj, "usage", None) or {}
+        prompt_tokens = getattr(usage, "prompt_tokens", None) or (usage.get("prompt_tokens", 0) if isinstance(usage, dict) else 0)
+        completion_tokens = getattr(usage, "completion_tokens", None) or (usage.get("completion_tokens", 0) if isinstance(usage, dict) else 0)
+
+        if stream and completion_tokens and (total_ms - ttft_ms) > 0:
+            tps = completion_tokens / ((total_ms - ttft_ms) / 1000.0)
+        elif completion_tokens and total_ms > 0:
+            tps = completion_tokens / (total_ms / 1000.0)
+        else:
+            tps = 0.0
+
+        model = kwargs.get("model", "unknown")
+        provider = getattr(response_obj, "model", model)
+        litellm_params = kwargs.get("litellm_params", {}) or {}
+        metadata = litellm_params.get("metadata", {}) if isinstance(litellm_params, dict) else {}
+        caller = metadata.get("caller", "unknown") if isinstance(metadata, dict) else "unknown"
+        agent_session = metadata.get("agent_session", "") if isinstance(metadata, dict) else ""
+        cost = getattr(response_obj, "_hidden_params", {}).get("response_cost", 0.0) if hasattr(response_obj, "_hidden_params") else 0.0
+
+        event = (
+            rid, start_ms / 1000.0, end_ms / 1000.0,
+            (start_ms + ttft_ms) / 1000.0 if ttft_ms else None,
+            model, str(provider), stream,
+            int(prompt_tokens or 0), int(completion_tokens or 0),
+            float(ttft_ms), float(total_ms), float(tps),
+            float(cost or 0.0), caller, agent_session, status, error,
+        )
+
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(event)
+                log.warning("telemetry queue full, dropped oldest event")
+            except Exception:
+                pass
+
+    async def _writer_loop(self) -> None:
+        """Drain queue in batches, bulk insert single transaction."""
+        log.info("telemetry writer loop started")
+        while True:
+            try:
+                batch = []
+                try:
+                    first = await asyncio.wait_for(self._queue.get(), timeout=FLUSH_INTERVAL_S)
+                    batch.append(first)
+                except asyncio.TimeoutError:
+                    continue
+
+                while len(batch) < BATCH_SIZE and not self._queue.empty():
+                    try:
+                        batch.append(self._queue.get_nowait())
+                    except asyncio.QueueEmpty:
+                        break
+
+                if not batch:
+                    continue
+
+                await self._bulk_insert(batch)
+            except Exception:
+                log.error("writer_loop error: %s", traceback.format_exc())
+                await asyncio.sleep(1.0)
+
+    async def _bulk_insert(self, batch: list) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._sync_bulk_insert, batch)
+
+    def _sync_bulk_insert(self, batch: list) -> None:
+        conn = sqlite3.connect(self.db_path, timeout=5)
+        try:
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.executemany(
+                """INSERT INTO llm_events
+                   (request_id, ts_start, ts_end, ts_first_token, model, provider, stream,
+                    prompt_tokens, completion_tokens, ttft_ms, total_ms, tps, cost_usd,
+                    caller, agent_session, status, error)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                batch,
+            )
+            conn.commit()
+        except Exception:
+            log.error("bulk insert failed: %s", traceback.format_exc())
+        finally:
+            conn.close()
+
+


### PR DESCRIPTION
## Summary

Config template + verification protocol for the `auto` virtual model across opencode instances (laptop, VPS-155).

## What's in the doc

- Per-machine config template (gateway provider entry + `auto` model key).
- Tailscale vs SSH tunnel baseURL differences (VPS-155 direct, laptop via tunnel).
- Sync flow via `sync-opencode-config.sh`.
- Post-#197-merge smoke tests: coding prompt, greeting, tool-call guard, gateway log inspection.
- Limitations: `auto` not yet on `main` (PR #272 pending), `semantic-router[local]` not yet in gateway requirements, no per-machine telemetry of auto-route decisions, no opencode skill defaulting to `auto`.

## Acceptance criteria (#203) — partial

- [x] Documented minimal per-machine config (just point at gateway + select `auto`)
- [x] Sync via existing `sync-opencode-config.sh` template flow
- [ ] `auto` selectable in opencode on laptop and VPS-155 — **BLOCKED on PR #272 merge + gateway redeploy**
- [ ] No manual provider switching to find a working model — **BLOCKED on PR #272 merge**

## Deferred (post-PR-#272-merge)

1. Merge PR #272 to `main`.
2. Redeploy gateway on VPS-40: `ssh ubuntu@40.233.101.233 'cd ~/LLM-API-Key-Proxy && git pull origin main && pip install -r requirements.txt && sudo systemctl restart llm-gateway'`.
3. Run the 4 smoke tests in the doc.
4. Add `auto` to local opencode.json `provider.vps-gateway.models`.
5. Sync to VPS-155 via `sync-opencode-config.sh`.
6. Restart opencode on both machines.
7. Verify `auto` shows in opencode model picker on both.

## Refs

- #194 (parent epic)
- #197 (PR #272 — `auto` impl, blocks full verification)
- #203 (this issue)