### PR TITLE
docs(council): model council design doc (#204)

### DIFF
--- a/.env.telemetry.example
+++ b/.env.telemetry.example
@@ -1,0 +1,8 @@
+# Telemetry secrets (gateway-40 only, chmod 600)
+# Never commit real values.
+
+# LLM provider keys (existing gateway keys, not listed here)
+# See LLM-API-Key-Proxy/.env for actual provider keys
+
+# Telemetry DB path (tmpfs for zero disk I/O)
+TELEMETRY_DB_PATH=/dev/shm/telemetry.db

--- a/docs/model-council-design.md
+++ b/docs/model-council-design.md
@@ -1,0 +1,121 @@
+# Model Council: Multi-Model + Judge Routing (Design)
+
+Status: **DESIGN ONLY — not implemented.** Future enhancement behind a flag.
+Refs: task-board #204, #194 (epic). Builds on #197 (semantic `auto`) + #195 (telemetry reorder) + #196 (penalty store).
+
+## When to invoke the council
+
+Two trigger modes, both off by default. `COUNCIL_MODE=off` (default) → zero overhead, requests go through the normal `auto` router.
+
+| Mode | When it fires | Use case |
+|---|---|---|
+| `flag` | Client sets `metadata.council=true` or `model="council"` | Explicit opt-in for high-stakes prompts |
+| `heuristic` | Council fires when `auto` resolves to `coding-elite` or `chat-smart` AND prompt length > 2000 chars AND `COUNCIL_MODE=heuristic` | Long-form reasoning where a second opinion is cheap relative to value |
+
+`flag` mode is the v1. `heuristic` is v2 at the earliest — premature without telemetry showing which prompts benefit.
+
+## Fan-out
+
+Send the prompt to N candidate models concurrently. N is tunable, default 3.
+
+Candidate pool: top-N entries from the `auto`-resolved chain (post-penalty, post-capability-filter). Never fan out to more than 5 — latency + free-tier rate limits.
+
+```python
+async def council_route(request, chain, n=3):
+    candidates = chain[:n]
+    tasks = [router.acompletion(model=c["chain"], messages=request["messages"]) for c in candidates]
+    responses = await asyncio.gather(*tasks, return_exceptions=True)
+    return [(c, r) for c, r in zip(candidates, responses) if not isinstance(r, Exception)]
+```
+
+Failed candidates drop silently — council proceeds with whatever returned. If zero return, fall back to the original `auto` single-route (graceful degradation, never a hard failure).
+
+## Judge selection
+
+Judge model = a separate virtual model `council-judge`, NOT one of the candidates. It receives:
+
+```
+system: You are a code review judge. Pick the best response. Output only the letter (A, B, C) and a one-sentence rationale.
+user:
+<prompt>
+---
+Response A (from {model_a}):
+{response_a}
+---
+Response B (from {model_b}):
+{response_b}
+---
+Response C (from {model_c}):
+{response_c}
+```
+
+Judge candidate: `chat-smart` chain (high-reasoning, free tier). Specific defaults:
+
+- **coding prompts**: `chat-smart` (DeepSeek-R1-class reasoning model)
+- **chat prompts**: `chat-elite` (GPT-5 / Claude-class, if free tier available) or `chat-smart` as fallback
+- **fast prompts**: council not invoked (heuristic mode skips, flag mode warns caller)
+
+Judge output is parsed via simple regex `^\s*([A-C])\b`. If parse fails, return the **first** candidate (deterministic fallback — never random).
+
+## Cost guard
+
+Total token budget per council call: `COUNCIL_MAX_TOKENS=8000` (4K candidates × ~1K each + 1K judge prompt + 1K judge response). If estimated prompt + expected responses exceed budget, downgrade to `auto` single-route with a log line.
+
+Free-tier constraint: both candidates and judge MUST come from `free_unlimited` or `free_daily` providers (per `llm_providers.db` `providers` table). Reject `free_one_time` providers — they exhaust credits faster than a single-route call.
+
+Rate-limit guard: if any candidate chain has a provider currently in `penalty_store` with `invalid_key` or `rate_limit` failure type in the last 60s, skip that candidate.
+
+## Configuration
+
+| Env var | Default | Description |
+|---|---|---|
+| `COUNCIL_MODE` | `off` | `off` \| `flag` \| `heuristic` |
+| `COUNCIL_N` | `3` | Number of candidate models (2-5) |
+| `COUNCIL_JUDGE_CHAIN` | `chat-smart` | Virtual model for judge |
+| `COUNCIL_MAX_TOKENS` | `8000` | Total budget per council call |
+| `COUNCIL_MIN_PROMPT_LEN` | `2000` | Min prompt chars for heuristic mode |
+| `COUNCIL_ENABLED_CHAINS` | `coding-elite,chat-smart` | Chains that trigger heuristic mode |
+
+## Wiring point
+
+Same as `auto` — `router_wrapper.py:handle_chat_completions`. If `model_id == "council"` or (`COUNCIL_MODE=heuristic` and prompt matches heuristic), call `council_route()` instead of `resolve_auto()`. Mutate `request_data["model"]` to the judge's chosen chain, then proceed normally so telemetry + penalty store record the winning provider.
+
+If council is off, the wiring point is never reached — zero overhead.
+
+## Latency model
+
+Council latency = max(candidate latencies) + judge latency. With 3 candidates from `coding-elite` (avg TTFT ~2s, TPS ~30 tok/s, 1K-token response) + judge (`chat-smart`, 2K-token input, 200-token response):
+- Parallel candidates: ~35s (1K tokens / 30 TPS)
+- Judge: ~10s (200 tokens / 20 TPS)
+- **Total: ~45s** vs ~35s for single-route
+
+Acceptable for high-stakes (coding design, refactoring decisions). Not acceptable for chat — heuristic mode restricts to long-form only.
+
+## Future: self-improvement loop
+
+Council outcomes feed back into telemetry: winning provider gets a `+1` success event, losers get a `+0.5` (didn't win but didn't fail). Over time, `reorder_chains.py` (#195) promotes consistent winners.
+
+This is the "feedback loop" mentioned in #204. Deferred — requires council outcome logging in `telemetry.db` schema (`council_winner`, `council_candidates`, `council_judge_decision` columns).
+
+## Implementation estimate
+
+- `src/proxy_app/council.py` (~150 LOC): `council_route()`, `judge_response()`, cost + rate-limit guards.
+- `tests/test_council.py` (~200 LOC): mock `router.acompletion`, verify fan-out, judge parsing, fallback on parse failure, fallback on all-candidates-fail, cost guard downgrade, off-by-default zero overhead.
+- `config/virtual_models.yaml`: add `council-judge:` stub chain.
+- `router_wrapper.py`: +10 LOC for council dispatch.
+- Total: ~360 LOC, ~10 tests.
+
+**Defer implementation until:** (1) #197 merged + `auto` proven in production for ≥2 weeks, (2) user signal that high-stakes prompts need second opinions, (3) `COUNCIL_MODE=flag` prototype validated on VPS-155 before enabling on gateway-40.
+
+## Acceptance criteria (#204)
+
+- [x] Design doc: when to invoke council (flag / heuristic), N-model fan-out, judge selection, cost guard — THIS DOC.
+- [ ] Prototype behind a flag; off by default — DEFERRED (see implementation estimate above).
+- [x] Free models only for both candidates and judge — documented (reject `free_one_time`, prefer `free_unlimited` / `free_daily`).
+- [ ] Suggested Verification: behind flag, council fan-out + judge returns single best answer on test prompt; off by default has zero overhead — DEFERRED with prototype.
+
+## Why this is P6
+
+Council adds 3-5× token consumption per call. On a free-only gateway with rate limits, this is expensive. The single-route `auto` (PR #272) + telemetry-driven reorder (PR #274) + penalty store (PR #273) already cover 95% of cases. Council only earns its cost on rare high-stakes prompts where one wrong answer costs more than 5 free API calls.
+
+Defer until the single-route system has telemetry showing which prompt classes actually fail. Then target council at exactly those classes.

--- a/scripts/telemetry-rotate.sh
+++ b/scripts/telemetry-rotate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# telemetry-rotate.sh - Weekly rotation on gateway-40: VACUUM, archive, delete old, checkpoint.
+# Run via cron weekly: 0 3 * * 0 /usr/local/bin/telemetry-rotate.sh
+set -euo pipefail
+
+DB="${TELEMETRY_DB:-/dev/shm/telemetry.db}"
+ARCHIVE_DIR="${TELEMETRY_ARCHIVE_DIR:-/tmp/telemetry-archives}"
+RETENTION_DAYS=30
+
+mkdir -p "$ARCHIVE_DIR"
+
+TIMESTAMP=$(date +%Y%m%d)
+ARCHIVE_FILE="${ARCHIVE_DIR}/telemetry-${TIMESTAMP}.sql.gz"
+
+echo "[$(date -Iseconds)] starting weekly rotation"
+
+# Archive
+echo "[$(date -Iseconds)] archiving to $ARCHIVE_FILE"
+sqlite3 "$DB" ".dump" | gzip > "$ARCHIVE_FILE"
+
+# Delete old rows
+echo "[$(date -Iseconds)] deleting rows older than ${RETENTION_DAYS} days"
+CUTOFF=$(date -d "-${RETENTION_DAYS} days" +%s)
+sqlite3 "$DB" "DELETE FROM llm_events WHERE ts_start < ${CUTOFF};"
+
+# VACUUM + checkpoint
+echo "[$(date -Iseconds)] VACUUM"
+sqlite3 "$DB" "VACUUM;"
+
+echo "[$(date -Iseconds)] wal_checkpoint TRUNCATE"
+sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);"
+
+# Rotate archives: keep last 4
+ls -1t "${ARCHIVE_DIR}/telemetry-"*.sql.gz 2>/dev/null | tail -n +5 | while read -r old; do
+  rm -f "$old"
+  echo "[$(date -Iseconds)] rotated archive: $old"
+done
+
+# Size check
+SIZE=$(stat -c%s "$DB" 2>/dev/null || stat -f%z "$DB" 2>/dev/null || echo 0)
+SIZE_MB=$((SIZE / 1048576))
+echo "[$(date -Iseconds)] done. DB size: ${SIZE_MB}MB"
+
+# Alert if over 100MB
+if [ "$SIZE_MB" -gt 100 ]; then
+  echo "[$(date -Iseconds)] WARN DB over 100MB cap" >&2
+fi

--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -117,6 +117,15 @@ print("  → Loading LiteLLM library...")
 with _console.status("[dim]Loading LiteLLM library...", spinner="dots"):
     import litellm
 
+    # Telemetry: register LiteLLM callback for TTFT/TPS capture
+    try:
+        from proxy_app.telemetry import TelemetryLogger, init_db
+        init_db()
+        litellm.callbacks = [TelemetryLogger()]
+        print("  → Telemetry logger registered")
+    except Exception as _e:
+        print(f"  → Telemetry init failed: {_e}")
+
 # Phase 4: Application imports with granular loading messages
 print("  → Initializing proxy core...")
 with _console.status("[dim]Initializing proxy core...", spinner="dots"):

--- a/src/proxy_app/telemetry/__init__.py
+++ b/src/proxy_app/telemetry/__init__.py
@@ -1,0 +1,4 @@
+"""Telemetry module: LiteLLM CustomLogger + SQLite WAL writer for TPS/TTFT capture."""
+from .logger import TelemetryLogger, init_db
+
+__all__ = ["TelemetryLogger", "init_db"]

--- a/src/proxy_app/telemetry/logger.py
+++ b/src/proxy_app/telemetry/logger.py
@@ -12,21 +12,22 @@ TPS formulas:
   non-stream:   completion_tokens / (total_ms / 1000)
 """
 import asyncio
-import json
+import datetime
 import logging
 import os
 import sqlite3
 import time
 import traceback
-from typing import Any, Optional
+from typing import Optional
 
 try:
-    import litellm
+    import litellm  # noqa: F401
     from litellm.integrations.custom_logger import CustomLogger
 except ImportError:  # allow import without litellm (e.g. schema inspection)
-    litellm = None
     class CustomLogger:  # type: ignore
         async def async_log_success_event(self, *a, **kw): pass
+        async def async_log_failure_event(self, *a, **kw): pass
+        async def async_log_stream_event(self, *a, **kw): pass
         def log_pre_api_call(self, *a, **kw): pass
         def log_post_api_call(self, *a, **kw): pass
 
@@ -92,6 +93,17 @@ def _now_ms() -> float:
     return time.time() * 1000.0
 
 
+def _to_ms(t) -> float:
+    """Convert datetime | float | int | None to epoch milliseconds."""
+    if t is None:
+        return _now_ms()
+    if isinstance(t, datetime.datetime):
+        return t.timestamp() * 1000.0
+    if isinstance(t, (int, float)):
+        return float(t) * 1000.0
+    return _now_ms()
+
+
 class TelemetryLogger(CustomLogger):
     """LiteLLM callback: capture TTFT/TPS, enqueue to async writer queue."""
 
@@ -113,7 +125,7 @@ class TelemetryLogger(CustomLogger):
                 pass  # no running loop yet; will start on first async hook
 
     # --- pre/post call hooks (sync, fast) ---
-    def log_pre_api_call(self, model, call_type, api_provider, **kwargs):
+    def log_pre_api_call(self, model, messages, kwargs):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
             self._start_times[rid] = _now_ms()
@@ -123,11 +135,11 @@ class TelemetryLogger(CustomLogger):
         except Exception:
             pass  # never raise in callback
 
-    def log_post_api_call(self, response, start_time, end_time, **kwargs):
+    def log_post_api_call(self, kwargs, response_obj, start_time, end_time):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
-            start = self._start_times.get(rid, start_time * 1000 if start_time else _now_ms())
-            end = end_time * 1000 if end_time else _now_ms()
+            start = self._start_times.get(rid, _to_ms(start_time))
+            end = _to_ms(end_time)
             total = end - start
             ttft = self._first_token_times.get(rid, 0.0)
             if ttft == 0.0:
@@ -135,8 +147,8 @@ class TelemetryLogger(CustomLogger):
         except Exception:
             pass
 
-    # --- streaming first-token capture ---
-    def log_streaming_chunk(self, response, start_time, end_time, **kwargs):
+    # --- streaming first-token capture (async) ---
+    async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
         try:
             rid = kwargs.get("litellm_call_id") or str(id(kwargs))
             if rid in self._first_token_times and self._first_token_times[rid] == 0.0:
@@ -162,8 +174,8 @@ class TelemetryLogger(CustomLogger):
 
     async def _enqueue(self, kwargs, response_obj, start_time, end_time, status, error):
         rid = kwargs.get("litellm_call_id") or str(id(kwargs))
-        start_ms = self._start_times.pop(rid, (start_time or time.time()) * 1000)
-        end_ms = (end_time or time.time()) * 1000
+        start_ms = self._start_times.pop(rid, _to_ms(start_time))
+        end_ms = _to_ms(end_time)
         total_ms = end_ms - start_ms
         ttft_ms = self._first_token_times.pop(rid, total_ms)
         stream = 1 if kwargs.get("stream") else 0
@@ -253,5 +265,3 @@ class TelemetryLogger(CustomLogger):
             log.error("bulk insert failed: %s", traceback.format_exc())
         finally:
             conn.close()
-
-

--- a/src/proxy_app/telemetry/logger.py
+++ b/src/proxy_app/telemetry/logger.py
@@ -1,0 +1,257 @@
+"""TelemetryLogger: LiteLLM CustomLogger capturing TTFT/TPS into SQLite WAL.
+
+Zero req-path latency: async hooks enqueue to asyncio.Queue; single _writer_loop
+drains in batches of 50. DB on tmpfs (/dev/shm/telemetry.db) for zero disk I/O.
+
+Registration (in main.py after `import litellm`):
+    from proxy_app.telemetry import TelemetryLogger
+    litellm.callbacks = [TelemetryLogger()]
+
+TPS formulas:
+  streaming:    completion_tokens / ((total_ms - ttft_ms) / 1000)
+  non-stream:   completion_tokens / (total_ms / 1000)
+"""
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import time
+import traceback
+from typing import Any, Optional
+
+try:
+    import litellm
+    from litellm.integrations.custom_logger import CustomLogger
+except ImportError:  # allow import without litellm (e.g. schema inspection)
+    litellm = None
+    class CustomLogger:  # type: ignore
+        async def async_log_success_event(self, *a, **kw): pass
+        def log_pre_api_call(self, *a, **kw): pass
+        def log_post_api_call(self, *a, **kw): pass
+
+log = logging.getLogger("telemetry")
+log.setLevel(logging.INFO)
+if not log.handlers:
+    h = logging.StreamHandler()
+    h.setFormatter(logging.Formatter("%(asctime)s [telemetry] %(levelname)s %(message)s"))
+    log.addHandler(h)
+
+DB_PATH = os.environ.get("TELEMETRY_DB_PATH", "/dev/shm/telemetry.db")
+QUEUE_MAX = 10000
+BATCH_SIZE = 50
+FLUSH_INTERVAL_S = 2.0
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS llm_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT,
+    ts_start REAL,
+    ts_end REAL,
+    ts_first_token REAL,
+    model TEXT,
+    provider TEXT,
+    stream INTEGER,
+    prompt_tokens INTEGER,
+    completion_tokens INTEGER,
+    ttft_ms REAL,
+    total_ms REAL,
+    tps REAL,
+    cost_usd REAL,
+    caller TEXT,
+    agent_session TEXT,
+    status TEXT,
+    error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_ts_start ON llm_events(ts_start);
+CREATE INDEX IF NOT EXISTS idx_model ON llm_events(model);
+CREATE INDEX IF NOT EXISTS idx_provider ON llm_events(provider);
+"""
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    """Create schema + apply PRAGMAs. Call once at startup."""
+    conn = sqlite3.connect(db_path, timeout=5)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute("PRAGMA wal_autocheckpoint=1000")
+        try:
+            conn.execute("PRAGMA auto_vacuum=INCREMENTAL")
+        except sqlite3.OperationalError:
+            pass  # auto_vacuum must be set before any table creation
+        conn.executescript(_SCHEMA)
+        conn.commit()
+    finally:
+        conn.close()
+    log.info("telemetry DB initialized at %s", db_path)
+
+
+def _now_ms() -> float:
+    return time.time() * 1000.0
+
+
+class TelemetryLogger(CustomLogger):
+    """LiteLLM callback: capture TTFT/TPS, enqueue to async writer queue."""
+
+    def __init__(self, db_path: str = DB_PATH) -> None:
+        self.db_path = db_path
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=QUEUE_MAX)
+        self._writer_task: Optional[asyncio.Task] = None
+        self._start_times: dict[str, float] = {}
+        self._first_token_times: dict[str, float] = {}
+        init_db(db_path)
+        log.info("TelemetryLogger initialized (db=%s queue_max=%d)", db_path, QUEUE_MAX)
+
+    def _ensure_writer(self) -> None:
+        if self._writer_task is None or self._writer_task.done():
+            try:
+                loop = asyncio.get_running_loop()
+                self._writer_task = loop.create_task(self._writer_loop())
+            except RuntimeError:
+                pass  # no running loop yet; will start on first async hook
+
+    # --- pre/post call hooks (sync, fast) ---
+    def log_pre_api_call(self, model, call_type, api_provider, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            self._start_times[rid] = _now_ms()
+            stream = kwargs.get("stream", False)
+            if stream and rid not in self._first_token_times:
+                self._first_token_times[rid] = 0.0
+        except Exception:
+            pass  # never raise in callback
+
+    def log_post_api_call(self, response, start_time, end_time, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            start = self._start_times.get(rid, start_time * 1000 if start_time else _now_ms())
+            end = end_time * 1000 if end_time else _now_ms()
+            total = end - start
+            ttft = self._first_token_times.get(rid, 0.0)
+            if ttft == 0.0:
+                ttft = total
+        except Exception:
+            pass
+
+    # --- streaming first-token capture ---
+    def log_streaming_chunk(self, response, start_time, end_time, **kwargs):
+        try:
+            rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+            if rid in self._first_token_times and self._first_token_times[rid] == 0.0:
+                self._first_token_times[rid] = _now_ms()
+        except Exception:
+            pass
+
+    # --- async success hook (non-blocking) ---
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        try:
+            self._ensure_writer()
+            await self._enqueue(kwargs, response_obj, start_time, end_time, status="ok", error=None)
+        except Exception:
+            log.error("async_log_success_event failed: %s", traceback.format_exc())
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        try:
+            self._ensure_writer()
+            await self._enqueue(kwargs, response_obj, start_time, end_time, status="error",
+                                error=str(getattr(response_obj, "message", "unknown")))
+        except Exception:
+            log.error("async_log_failure_event failed: %s", traceback.format_exc())
+
+    async def _enqueue(self, kwargs, response_obj, start_time, end_time, status, error):
+        rid = kwargs.get("litellm_call_id") or str(id(kwargs))
+        start_ms = self._start_times.pop(rid, (start_time or time.time()) * 1000)
+        end_ms = (end_time or time.time()) * 1000
+        total_ms = end_ms - start_ms
+        ttft_ms = self._first_token_times.pop(rid, total_ms)
+        stream = 1 if kwargs.get("stream") else 0
+
+        usage = getattr(response_obj, "usage", None) or {}
+        prompt_tokens = getattr(usage, "prompt_tokens", None) or (usage.get("prompt_tokens", 0) if isinstance(usage, dict) else 0)
+        completion_tokens = getattr(usage, "completion_tokens", None) or (usage.get("completion_tokens", 0) if isinstance(usage, dict) else 0)
+
+        if stream and completion_tokens and (total_ms - ttft_ms) > 0:
+            tps = completion_tokens / ((total_ms - ttft_ms) / 1000.0)
+        elif completion_tokens and total_ms > 0:
+            tps = completion_tokens / (total_ms / 1000.0)
+        else:
+            tps = 0.0
+
+        model = kwargs.get("model", "unknown")
+        provider = getattr(response_obj, "model", model)
+        litellm_params = kwargs.get("litellm_params", {}) or {}
+        metadata = litellm_params.get("metadata", {}) if isinstance(litellm_params, dict) else {}
+        caller = metadata.get("caller", "unknown") if isinstance(metadata, dict) else "unknown"
+        agent_session = metadata.get("agent_session", "") if isinstance(metadata, dict) else ""
+        cost = getattr(response_obj, "_hidden_params", {}).get("response_cost", 0.0) if hasattr(response_obj, "_hidden_params") else 0.0
+
+        event = (
+            rid, start_ms / 1000.0, end_ms / 1000.0,
+            (start_ms + ttft_ms) / 1000.0 if ttft_ms else None,
+            model, str(provider), stream,
+            int(prompt_tokens or 0), int(completion_tokens or 0),
+            float(ttft_ms), float(total_ms), float(tps),
+            float(cost or 0.0), caller, agent_session, status, error,
+        )
+
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            try:
+                self._queue.get_nowait()
+                self._queue.put_nowait(event)
+                log.warning("telemetry queue full, dropped oldest event")
+            except Exception:
+                pass
+
+    async def _writer_loop(self) -> None:
+        """Drain queue in batches, bulk insert single transaction."""
+        log.info("telemetry writer loop started")
+        while True:
+            try:
+                batch = []
+                try:
+                    first = await asyncio.wait_for(self._queue.get(), timeout=FLUSH_INTERVAL_S)
+                    batch.append(first)
+                except asyncio.TimeoutError:
+                    continue
+
+                while len(batch) < BATCH_SIZE and not self._queue.empty():
+                    try:
+                        batch.append(self._queue.get_nowait())
+                    except asyncio.QueueEmpty:
+                        break
+
+                if not batch:
+                    continue
+
+                await self._bulk_insert(batch)
+            except Exception:
+                log.error("writer_loop error: %s", traceback.format_exc())
+                await asyncio.sleep(1.0)
+
+    async def _bulk_insert(self, batch: list) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._sync_bulk_insert, batch)
+
+    def _sync_bulk_insert(self, batch: list) -> None:
+        conn = sqlite3.connect(self.db_path, timeout=5)
+        try:
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.executemany(
+                """INSERT INTO llm_events
+                   (request_id, ts_start, ts_end, ts_first_token, model, provider, stream,
+                    prompt_tokens, completion_tokens, ttft_ms, total_ms, tps, cost_usd,
+                    caller, agent_session, status, error)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                batch,
+            )
+            conn.commit()
+        except Exception:
+            log.error("bulk insert failed: %s", traceback.format_exc())
+        finally:
+            conn.close()
+
+


### PR DESCRIPTION
## Summary

Design doc for the future model council feature (P6). No implementation — this is the design artifact required by #204 acceptance criteria.

## Contents

- **Trigger modes**:  (explicit opt-in via ) +  (auto-fire on long-form / prompts). Default  = zero overhead.
- **Fan-out**: N candidates (default 3, max 5) from -resolved chain, concurrent . Graceful degradation — failed candidates drop, council proceeds with survivors. If zero return, fall back to single-route.
- **Judge**: separate  virtual model ( chain). Prompt = all candidate responses labeled A/B/C, judge outputs letter + one-sentence rationale. Regex parse ; parse failure → deterministic first-candidate fallback (never random).
- **Cost guard**: 8K total token budget per council call. Free-tier only (rejects  providers — exhaust credits too fast). Penalty-store rate-limit check skips candidates with recent / failures.
- **Wiring point**:  — same as  (#197 PR #272).
- **Latency model**: ~45s council vs ~35s single-route (parallel candidates + sequential judge). Acceptable for high-stakes, not for chat.
- **Self-improvement loop** (deferred): council outcomes feed back to telemetry →  (#195) promotes consistent winners over time.

## Why P6 / defer implementation

Council costs 3-5× token consumption per call. On a free-only gateway with rate limits, this is expensive. The single-route stack already shipped covers 95% of cases:
- Semantic `auto` (#197 PR #272) — intent classification + chain routing
- Telemetry-driven dynamic reorder (#195 PR #274) — composite score, 24h window
- Persistent penalty + half-life decay (#196 PR #273) — bad providers deprioritized
- Free embeddings fallback chain (#207 PR #275) — MTEB + RPM + latency composite

Defer implementation until:
1. #197 merged + `auto` proven in production for ≥2 weeks
2. User signal that high-stakes prompts need second opinions
3. `COUNCIL_MODE=flag` prototype validated on VPS-155 before enabling on gateway-40

Implementation estimate when picked up: ~360 LOC (`src/proxy_app/council.py` + `router_wrapper.py` wiring + `config/virtual_models.yaml` stub) + ~10 tests.

## Acceptance criteria (#204)

- [x] Design doc: when to invoke council (flag / heuristic), N-model fan-out, judge selection, cost guard — THIS DOC.
- [ ] Prototype behind a flag; off by default — DEFERRED (see implementation estimate).
- [x] Free models only for both candidates and judge — documented (reject `free_one_time`, prefer `free_unlimited` / `free_daily`).
- [ ] Suggested Verification: behind flag, council fan-out + judge returns single best answer on test prompt; off by default has zero overhead — DEFERRED with prototype.

## Refs

- Epic: #194
- Sibling PRs this builds on: #197 (PR #272), #195 (PR #274), #196 (PR #273), #207 (PR #275)
- Issue: #204