### PR TITLE
feat(telemetry): persist rate-limit hits + provider health (#342)

### DIFF
--- a/scripts/export_telemetry_summary.py
+++ b/scripts/export_telemetry_summary.py
@@ -63,6 +63,66 @@ def export_telemetry_summary(hours: int = 168):
             "max_latency_ms": round(row["max_latency_ms"] or 0, 1),
         }
 
+    # Active rate-limit blocks (latest row per provider/model with a future
+    # reset_time). Feeds router cooldown decisions + phase-router diagnostics.
+    cursor.execute(
+        """
+        SELECT provider, model, limit_type, current_count, limit_limit,
+               reset_time, last_updated
+        FROM rate_limits
+        WHERE reset_time IS NOT NULL
+          AND (provider, model, last_updated) IN (
+              SELECT provider, model, MAX(last_updated)
+              FROM rate_limits
+              GROUP BY provider, model
+          )
+    """
+    )
+    rate_limits = {}
+    now = datetime.now()
+    for row in cursor.fetchall():
+        reset_time = row["reset_time"]
+        try:
+            reset_dt = datetime.fromisoformat(reset_time)
+            retry_after_ms = max(0, int((reset_dt - now).total_seconds() * 1000))
+        except (ValueError, TypeError):
+            retry_after_ms = None
+        rate_limits[f"{row['provider']}/{row['model']}"] = {
+            "provider": row["provider"],
+            "model": row["model"],
+            "limit_type": row["limit_type"],
+            "current_count": row["current_count"],
+            "limit_limit": row["limit_limit"],
+            "reset_time": reset_time,
+            "retry_after_ms": retry_after_ms,
+            "last_updated": row["last_updated"],
+        }
+
+    # Latest health snapshot per provider/model (most recent check).
+    cursor.execute(
+        """
+        SELECT provider, model, is_healthy, failure_rate,
+               consecutive_failures, last_check_time, last_success_time
+        FROM provider_health
+        WHERE (provider, model, last_check_time) IN (
+            SELECT provider, model, MAX(last_check_time)
+            FROM provider_health
+            GROUP BY provider, model
+        )
+    """
+    )
+    health = {}
+    for row in cursor.fetchall():
+        health[f"{row['provider']}/{row['model'] or '*'}"] = {
+            "provider": row["provider"],
+            "model": row["model"],
+            "is_healthy": bool(row["is_healthy"]),
+            "failure_rate": row["failure_rate"] or 0,
+            "consecutive_failures": row["consecutive_failures"] or 0,
+            "last_check_time": row["last_check_time"],
+            "last_success_time": row["last_success_time"],
+        }
+
     conn.close()
 
     summary = {
@@ -71,6 +131,8 @@ def export_telemetry_summary(hours: int = 168):
         "total_providers": len(set(p.split("/")[0] for p in providers.keys())),
         "total_models": len(providers),
         "providers": providers,
+        "rate_limits": rate_limits,
+        "provider_health": health,
     }
 
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/src/proxy_app/health_checker.py
+++ b/src/proxy_app/health_checker.py
@@ -102,6 +102,26 @@ class HealthChecker:
             provider_name, status = result
             self.provider_status[provider_name] = status
 
+            # Persist to telemetry so router scoring + restart survival see
+            # real health state. Maps "healthy" -> True, everything else
+            # (unhealthy/error/skipped) -> False with the ping latency when
+            # available.
+            try:
+                from rotator_library.telemetry import get_telemetry_manager
+
+                is_healthy = status.get("status") == "healthy"
+                latency = status.get("avg_latency_ms")
+                get_telemetry_manager().update_provider_health(
+                    provider=provider_name,
+                    model=status.get("model_used"),
+                    is_healthy=is_healthy,
+                    failure_rate=0.0 if is_healthy else 1.0,
+                )
+                if latency is not None:
+                    _ = latency  # available for future latency-aware scoring
+            except Exception as e:
+                logger.debug(f"Could not persist health for {provider_name}: {e}")
+
     async def _ping_provider(self, provider: str, model: str) -> bool:
         """Send a minimal request to the provider."""
         try:

--- a/src/proxy_app/rate_limiter.py
+++ b/src/proxy_app/rate_limiter.py
@@ -52,9 +52,7 @@ def _resolve_tz(tz_name: str):
         try:
             return ZoneInfo(tz_name)
         except Exception as e:  # pragma: no cover - defensive
-            logger.warning(
-                f"Unknown timezone '{tz_name}', falling back to UTC: {e}"
-            )
+            logger.warning(f"Unknown timezone '{tz_name}', falling back to UTC: {e}")
     return timezone.utc
 
 
@@ -167,9 +165,7 @@ class RateLimitTracker:
                 f"Failed to save active days to {self._active_days_path}: {e}"
             )
 
-    def configure_active_days_windows(
-        self, windows: Dict[str, Dict[str, Any]]
-    ) -> None:
+    def configure_active_days_windows(self, windows: Dict[str, Dict[str, Any]]) -> None:
         """Configure per-provider active-day window caps.
 
         Example::
@@ -194,9 +190,7 @@ class RateLimitTracker:
             f"{len(self._active_days_windows)} providers"
         )
 
-    def _prune_active_days(
-        self, provider: str, today: date_cls
-    ) -> Set[str]:
+    def _prune_active_days(self, provider: str, today: date_cls) -> Set[str]:
         """Drop active dates older than (today - window_days + 1)."""
         cfg = self._active_days_windows.get(provider)
         if not cfg:
@@ -209,9 +203,7 @@ class RateLimitTracker:
             existing -= to_remove
         return existing
 
-    def check_active_days(
-        self, provider: str
-    ) -> Tuple[bool, str, Dict[str, Any]]:
+    def check_active_days(self, provider: str) -> Tuple[bool, str, Dict[str, Any]]:
         """Check whether a provider may be used under its active-day window.
 
         Returns ``(allowed, reason, info)``. ``info`` is a dict with::
@@ -247,9 +239,7 @@ class RateLimitTracker:
         if used >= limit and pruned:
             oldest = date_cls.fromisoformat(min(pruned))
             unlock_date = oldest + timedelta(days=cfg["window_days"])
-            unlock_dt = datetime.combine(
-                unlock_date, dt_time(0, 0, 0), tzinfo=tz
-            )
+            unlock_dt = datetime.combine(unlock_date, dt_time(0, 0, 0), tzinfo=tz)
             info["next_slot_unlocks_on"] = unlock_dt.isoformat()
             return False, REASON_USAGE_CAP, info
         return True, "", info
@@ -275,9 +265,7 @@ class RateLimitTracker:
         existing.add(date_str)
         # Opportunistic prune on record
         today = _today_in_tz(cfg["tzinfo"])
-        cutoff_iso = (
-            today - timedelta(days=cfg["window_days"] - 1)
-        ).isoformat()
+        cutoff_iso = (today - timedelta(days=cfg["window_days"] - 1)).isoformat()
         to_remove = {d for d in existing if d < cutoff_iso}
         if to_remove:
             existing -= to_remove
@@ -347,6 +335,29 @@ class RateLimitTracker:
             # Check hard rate limit backoff
             if now < status.rate_limited_until:
                 return False, status.block_reason or REASON_RATE_LIMIT
+
+            # Restart survival: if no in-memory block is active, consult the
+            # persisted DB. A prior process may have recorded a rate-limit hit
+            # whose reset_time is still in the future. If so, restore the
+            # in-memory block and refuse. Runs only when in-memory has no
+            # active block so it never overrides a freshly-observed 429.
+            try:
+                from rotator_library.telemetry import get_telemetry_manager
+
+                is_limited, retry_after_ms = get_telemetry_manager().check_rate_limit(
+                    prov_name, model
+                )
+                if is_limited and retry_after_ms and retry_after_ms > 0:
+                    restored_until = now + (retry_after_ms / 1000.0)
+                    status.rate_limited_until = restored_until
+                    status.block_reason = REASON_RATE_LIMIT
+                    logger.info(
+                        f"Restored persisted rate-limit block for {key} "
+                        f"(retry_after={retry_after_ms}ms)"
+                    )
+                    return False, REASON_RATE_LIMIT
+            except Exception as e:
+                logger.debug(f"Could not consult persisted rate limit: {e}")
 
             # Active-days window check (on-the-fly; must run under lock so
             # pruning + check are consistent with the in-memory set). If the
@@ -493,6 +504,23 @@ class RateLimitTracker:
                 f"Provider {key} blocked ({reason}) until "
                 f"{datetime.fromtimestamp(block_until, tz=timezone.utc).isoformat()}"
             )
+
+        # Persist so a fresh process can restore the block before the reset
+        # time elapses (restart survival). Telemetry uses its own sqlite
+        # connection (outside the asyncio lock), so this is async-safe.
+        try:
+            from rotator_library.telemetry import get_telemetry_manager
+
+            reset_dt = datetime.fromtimestamp(block_until, tz=timezone.utc)
+            get_telemetry_manager().record_rate_limit_hit(
+                provider=prov_name,
+                model=model,
+                limit_type=("usage_cap" if reason == REASON_USAGE_CAP else "rpm"),
+                retry_after=retry_after,
+                reset_time=reset_dt.isoformat(),
+            )
+        except Exception as e:
+            logger.debug(f"Could not persist rate-limit hit: {e}")
 
     async def get_usage_stats(self) -> Dict[str, Any]:
         """Get current usage statistics, including active-day state per provider."""

--- a/src/rotator_library/telemetry.py
+++ b/src/rotator_library/telemetry.py
@@ -385,15 +385,30 @@ class TelemetryManager:
         }
 
     def cleanup_old_data(self, days: int = 7):
-        """Remove telemetry data older than specified days."""
+        """Remove telemetry data older than specified days across all tables."""
         cutoff = datetime.now() - timedelta(days=days)
 
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
 
         cursor.execute("DELETE FROM api_calls WHERE timestamp < ?", (cutoff,))
-
         deleted = cursor.rowcount
+
+        # rate_limits + provider_health + tps_metrics were added alongside
+        # api_calls; purge them on the same rolling window so the DB stays
+        # bounded on the 1GB VPS. rate_limits resets via new INSERTs rather
+        # than UPDATE, so stale rows have no reset_time or expired ones.
+        cursor.execute("DELETE FROM rate_limits WHERE last_updated < ?", (cutoff,))
+        deleted += cursor.rowcount
+
+        cursor.execute(
+            "DELETE FROM provider_health WHERE last_check_time < ?", (cutoff,)
+        )
+        deleted += cursor.rowcount
+
+        cursor.execute("DELETE FROM tps_metrics WHERE timestamp < ?", (cutoff,))
+        deleted += cursor.rowcount
+
         conn.commit()
         conn.close()
 
@@ -427,6 +442,58 @@ class TelemetryManager:
         except Exception as e:
             logger.error(f"Failed to increment rate limit: {e}")
 
+    def record_rate_limit_hit(
+        self,
+        provider: str,
+        model: str,
+        limit_type: str = "rpm",
+        retry_after: float = 60.0,
+        reset_time: Optional[str] = None,
+    ):
+        """Record an explicit rate-limit hit with a reset time.
+
+        Complements ``increment_rate_limit`` (counter-only) by persisting
+        ``reset_time`` so ``check_rate_limit`` can compute retry_after
+        across process restarts. Called by RateLimitTracker when an
+        upstream 429/usage-cap is observed.
+        """
+        try:
+            if reset_time is None:
+                reset_time = (
+                    datetime.now() + timedelta(seconds=retry_after)
+                ).isoformat()
+
+            conn = sqlite3.connect(self.db_path)
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO rate_limits
+                (provider, model, limit_type, current_count, reset_time,
+                 last_updated)
+                VALUES (?, ?, ?,
+                        COALESCE(
+                            (SELECT current_count FROM rate_limits
+                             WHERE provider = ? AND model = ?
+                               AND limit_type = ?),
+                            0) + 1,
+                        ?, CURRENT_TIMESTAMP)
+            """,
+                (
+                    provider,
+                    model,
+                    limit_type,
+                    provider,
+                    model,
+                    limit_type,
+                    reset_time,
+                ),
+            )
+            conn.commit()
+            conn.close()
+
+        except Exception as e:
+            logger.error(f"Failed to record rate limit hit: {e}")
+
     def check_rate_limit(
         self,
         provider: str,
@@ -457,16 +524,30 @@ class TelemetryManager:
 
             current, limit_value, reset_time = row
 
-            if limit_value and current >= limit_value:
-                if reset_time:
-                    try:
-                        reset_dt = datetime.fromisoformat(reset_time)
-                        retry_after = max(
-                            0, int((reset_dt - datetime.now()).total_seconds() * 1000)
-                        )
+            # If a future reset_time is recorded, treat as limited even when
+            # limit_value is NULL (rate-limit hit persisted via
+            # record_rate_limit_hit without a known numeric cap).
+            if reset_time:
+                try:
+                    reset_dt = datetime.fromisoformat(reset_time)
+                    # reset_time may be tz-aware (from rate_limiter's UTC
+                    # timestamp) or naive (CURRENT_TIMESTAMP). Compare in a
+                    # tz-consistent way to avoid aware-vs-naive TypeError.
+                    if reset_dt.tzinfo is not None:
+                        now_dt = datetime.now(reset_dt.tzinfo)
+                    else:
+                        now_dt = datetime.now()
+                    retry_after = max(
+                        0,
+                        int((reset_dt - now_dt).total_seconds() * 1000),
+                    )
+                    if retry_after > 0:
                         return True, retry_after
-                    except (ValueError, TypeError):
-                        pass
+                    # Reset time has passed -> not limited; fall through
+                except (ValueError, TypeError):
+                    pass
+
+            if limit_value and current >= limit_value:
                 return True, 60000
 
             return False, None
@@ -505,19 +586,37 @@ class TelemetryManager:
         is_healthy: bool,
         failure_rate: float = 0,
     ):
-        """Update provider health status."""
+        """Update provider health status.
+
+        provider_health has no UNIQUE constraint, so ``INSERT OR REPLACE``
+        would always start consecutive_failures from NULL (-> 1). We
+        read the latest existing consecutive_failures via a subquery so
+        failures accumulate across checks.
+        """
         try:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
-
             cursor.execute(
                 """
-                INSERT OR REPLACE INTO provider_health
+                INSERT INTO provider_health
                 (provider, model, is_healthy, last_check_time, failure_rate,
                  consecutive_failures, last_success_time)
                 VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?,
-                 CASE WHEN ? = 1 THEN 0 ELSE consecutive_failures + 1 end,
-                 CASE WHEN ? = 1 THEN CURRENT_TIMESTAMP ELSE last_success_time end)
+                 CASE WHEN ? = 1
+                      THEN 0
+                      ELSE COALESCE(
+                          (SELECT consecutive_failures
+                             FROM provider_health
+                            WHERE provider = ?
+                              AND (model IS ? OR model = ?)
+                            ORDER BY last_check_time DESC, rowid DESC
+                            LIMIT 1),
+                          0) + 1
+                 END,
+                 CASE WHEN ? = 1
+                      THEN CURRENT_TIMESTAMP
+                      ELSE NULL
+                 END)
             """,
                 (
                     provider,
@@ -525,10 +624,12 @@ class TelemetryManager:
                     is_healthy,
                     failure_rate,
                     int(is_healthy),
+                    provider,
+                    model,
+                    model,
                     int(is_healthy),
                 ),
             )
-
             conn.commit()
             conn.close()
 
@@ -551,7 +652,7 @@ class TelemetryManager:
                     SELECT is_healthy, failure_rate, consecutive_failures, last_success_time
                     FROM provider_health
                     WHERE provider = ? AND model = ?
-                    ORDER BY last_check_time DESC
+                    ORDER BY last_check_time DESC, rowid DESC
                     LIMIT 1
                 """,
                     (provider, model),
@@ -992,7 +1093,9 @@ class TelemetryManager:
         except Exception as e:
             logger.error(f"Failed to mark LLM provider exhausted: {e}")
 
-    def reset_daily_llm_provider_credits(self, provider: Optional[str] = None, api_key: Optional[str] = None):
+    def reset_daily_llm_provider_credits(
+        self, provider: Optional[str] = None, api_key: Optional[str] = None
+    ):
         """Reset daily_renewable providers (or a single key) when reset_date has passed.
 
         When called with no args, resets all due daily_renewable entries (suitable for cron).
@@ -1035,9 +1138,7 @@ class TelemetryManager:
             affected = cursor.rowcount
             conn.close()
             if affected:
-                logger.info(
-                    f"Reset daily LLM provider credits for {affected} entries"
-                )
+                logger.info(f"Reset daily LLM provider credits for {affected} entries")
             return affected
 
         except Exception as e:


### PR DESCRIPTION
Closes #342

## What
Wires the in-memory rate limiter + health checker to the telemetry DB so rate-limit blocks and provider health survive process restarts, and extends the telemetry summary exporter to surface both.

## Changes
- **telemetry.record_rate_limit_hit** (new): persists reset_time + limit_type so check_rate_limit can restore a block after restart.
- **telemetry.check_rate_limit**: honors a future reset_time even when limit_value is NULL; fixes an aware-vs-naive datetime comparison that silently fell through to not-limited.
- **telemetry.update_provider_health**: fixes consecutive_failures never accumulating (INSERT OR REPLACE with no UNIQUE constraint reset it to NULL+1 each call). Now reads the prior latest row via subquery with a rowid DESC tiebreaker; get_provider_health ordering gets the same tiebreaker.
- **telemetry.cleanup_old_data**: purges rate_limits, provider_health, tps_metrics on the same 7-day window as api_calls.
- **rate_limiter.record_rate_limit_hit**: persists to telemetry after the in-memory set (async-safe; telemetry owns its own sqlite conn).
- **rate_limiter.can_use_provider**: restart-survival — when no in-memory block is active, consults the persisted DB and restores the block if a future reset_time is recorded.
- **health_checker._check_all_providers**: persists each provider result via update_provider_health.
- **export_telemetry_summary**: adds rate_limits + provider_health sections.

## Verification
- `python3 -m py_compile` on all 4 files: OK
- Standalone smoke test (5 assertions): future-reset limited, expired-reset not limited, consecutive_failures accumulates then resets on success, cleanup purges all 3 new tables.
- Integration test (3 assertions): restart-survival restores block from persisted DB, expired DB block does not block, record_rate_limit_hit round-trips through check_rate_limit.
- No new >88-char lines introduced (pre-existing over-length lines untouched).

## Acceptance criteria (#342)
- [x] rate_limits + provider_health tables exist (no destructive migration — CREATE TABLE IF NOT EXISTS)
- [x] RateLimitTracker.record_rate_limit_hit persists to telemetry
- [x] HealthChecker._check_all_providers persists (success + failure)
- [x] 7-day rolling window cleanup covers all tables
- [x] can_use_provider consults persisted rate-limit status (restart survival)
- [x] status_api / telemetry_summary.json regenerates with rate-limit + health sections
- [x] Backward compatible (no schema changes, additive only)

## Notes
- VPS is behind origin/main by several commits with uncommitted config changes; this PR edits the local clone on a fresh branch off origin/main so the VPS can pull when ready without disturbing live config.
- Depends on the existing `get_telemetry_manager()` singleton (no new constructor args).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer telemetry export with rate-limit and provider health snapshots.
  * Provider health updates and rate-limit events are now saved so status can persist across restarts.

* **Bug Fixes**
  * Rate-limited providers are now detected from stored telemetry even after a restart.
  * Health checks now retain recent failure streaks more accurately.

* **Chores**
  * Cleaned up old telemetry data across all related records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->