### PR TITLE
Enforce free-model baseline: demote worse-than-free during chain reorder (#343)

### DIFF
--- a/scripts/reorder_chains.py
+++ b/scripts/reorder_chains.py
@@ -177,7 +177,9 @@ def load_telemetry(
                 (cutoff,),
             )
         else:
-            logger.info("llm_events lacks concrete_provider/concrete_model; using alias columns")
+            logger.info(
+                "llm_events lacks concrete_provider/concrete_model; using alias columns"
+            )
             cur = conn.execute(
                 """
                 SELECT provider, model,
@@ -265,7 +267,9 @@ def compute_composite(
 
     success = max(0.0, min(1.0, stat.success_rate))
     tps_norm = max(0.0, min(1.0, stat.avg_tps / max_tps)) if max_tps > 0 else 0.0
-    ttft_norm = max(0.0, 1.0 - (stat.avg_ttft_ms / max_ttft_ms)) if max_ttft_ms > 0 else 0.0
+    ttft_norm = (
+        max(0.0, 1.0 - (stat.avg_ttft_ms / max_ttft_ms)) if max_ttft_ms > 0 else 0.0
+    )
     penalty_inv = 1.0 / (1.0 + max(0.0, penalty))
 
     score = (
@@ -310,9 +314,7 @@ def reorder_chain(
         entry = ChainEntry(provider, model, priority, idx)
         stat = stats.get((provider, model))
         pen = penalties.get((provider, model), 0.0)
-        score, reason = compute_composite(
-            stat, pen, min_samples, max_tps, max_ttft_ms
-        )
+        score, reason = compute_composite(stat, pen, min_samples, max_tps, max_ttft_ms)
         entries.append((entry, score, reason))
 
     # ponytail: stable sort — entries with score=-1 (insufficient samples)
@@ -333,6 +335,91 @@ def reorder_chain(
             f"  #{new_idx + 1} {entry.provider}/{entry.model}: score={score:.3f} — {reason}"
         )
     return new_chain, reasons
+
+
+# ---------------------------------------------------------------------------
+# Free-model baseline enforcement (#343)
+# ---------------------------------------------------------------------------
+
+
+def is_free_provider(provider: str, categories: Dict[str, object]) -> bool:
+    """True if the provider is classified as free-tier.
+
+    Duck-types ProviderCategory.kind from rank_models — avoids importing
+    rank_models here. Free kinds: free_unlimited, free_daily, free_one_time,
+    no_key. Anything else (paid, unknown, missing) is not free.
+    """
+    cat = categories.get(provider)
+    if cat is None:
+        return False
+    kind = getattr(cat, "kind", "paid")
+    return kind in ("free_unlimited", "free_daily", "free_one_time", "no_key")
+
+
+def apply_free_baseline(
+    chain: List[Dict],
+    score_lookup: Dict[Tuple[str, str], float],
+    categories: Dict[str, object],
+    baseline_floor_min: float = 0.0,
+) -> Tuple[List[Dict], List[str]]:
+    """Demote non-free entries scoring below the free-tier quality floor.
+
+    Baseline = min score among free entries with a valid (>=0) score.
+    Floor = max(baseline, baseline_floor_min). Any non-free entry with a
+    valid (>=0) score strictly below the floor is moved to a last-resort
+    priority slot (99, 100, ...). Entries with invalid scores (e.g. -1
+    insufficient samples) are never demoted — they keep their ranked
+    position so untested-but-potentially-good models aren't penalised.
+
+    Returns (new_chain, log_lines). When no free entries have valid scores,
+    returns the chain unchanged (current-behaviour fallback per #343).
+    """
+    free_scores = [
+        score_lookup.get((c.get("provider", ""), c.get("model", "")))
+        for c in chain
+        if is_free_provider(c.get("provider", ""), categories)
+    ]
+    free_scores = [s for s in free_scores if s is not None and s >= 0]
+    if not free_scores:
+        return chain, []  # no free data -> fall back to current behaviour
+
+    baseline = min(free_scores)
+    floor = max(baseline, baseline_floor_min)
+
+    kept: List[Dict] = []
+    demoted: List[Dict] = []
+    log_lines: List[str] = []
+    for c in chain:
+        provider = c.get("provider", "")
+        model = c.get("model", "")
+        score = score_lookup.get((provider, model))
+        if (
+            not is_free_provider(provider, categories)
+            and score is not None
+            and score >= 0
+            and score < floor
+        ):
+            demoted.append(c)
+            log_lines.append(
+                f"[BASELINE] {provider}/{model} score={score:.4f} "
+                f"demoted below free baseline {floor:.4f}"
+            )
+        else:
+            kept.append(c)
+
+    if not demoted:
+        return chain, log_lines  # order unchanged, but log_lines may be empty
+
+    new_chain: List[Dict] = []
+    for idx, c in enumerate(kept):
+        new_entry = dict(c)
+        new_entry["priority"] = idx + 1
+        new_chain.append(new_entry)
+    for idx, c in enumerate(demoted):
+        new_entry = dict(c)
+        new_entry["priority"] = 99 + idx
+        new_chain.append(new_entry)
+    return new_chain, log_lines
 
 
 def reorder_config(
@@ -382,8 +469,18 @@ def reorder_config(
             f"stats={len(stats)} pen={len(penalties)}"
         )
     else:
+        # #343: provider categories needed for the free-baseline filter even
+        # in composite mode. Loaded once, reused across all chains.
+        try:
+            rm = _get_rank_models()
+            cats = rm.load_provider_categories()
+        except Exception as exc:
+            logger.debug(
+                "provider categories unavailable, free-baseline skipped: %r",
+                exc,
+            )
         log_lines_intro = (
-            f"composite mode: stats={len(stats)} pen={len(penalties)}"
+            f"composite mode: stats={len(stats)} pen={len(penalties)} cats={len(cats)}"
         )
 
     log_lines: List[str] = [log_lines_intro]
@@ -400,6 +497,10 @@ def reorder_config(
             new_chain, reasons_raw = rm.rank_chain(
                 chain, stats, penalties, bench, cats, tier
             )
+            # Build score lookup from RankReason objects for #343 baseline.
+            score_lookup: Dict[Tuple[str, str], float] = {
+                (r.provider, r.model): r.score for r in reasons_raw
+            }
             reasons = [
                 f"  #{i + 1} {r.provider}/{r.model}: U={r.score:.4f} — {r.reason}"
                 for i, r in enumerate(reasons_raw)
@@ -408,6 +509,27 @@ def reorder_config(
             new_chain, reasons = reorder_chain(
                 chain, stats, penalties, min_samples, max_tps, max_ttft_ms
             )
+            # Build score lookup by recomputing composite per entry.
+            score_lookup = {}
+            for c in chain:
+                prov = c.get("provider", "")
+                mdl = c.get("model", "")
+                stat = stats.get((prov, mdl))
+                pen = penalties.get((prov, mdl), 0.0)
+                s, _ = compute_composite(stat, pen, min_samples, max_tps, max_ttft_ms)
+                score_lookup[(prov, mdl)] = s
+
+        # #343: free-model baseline — demote non-free entries scoring below
+        # the worst free entry to last-resort (priority 99). Only applies
+        # when provider categories are available.
+        if cats:
+            new_chain, baseline_logs = apply_free_baseline(
+                new_chain, score_lookup, cats
+            )
+            if baseline_logs:
+                log_lines.append(f"[{model_id}] free-baseline demotions:")
+                log_lines.extend(f"  {line}" for line in baseline_logs)
+
         new_order = [(c.get("provider"), c.get("model")) for c in new_chain]
         if new_order != original_order:
             reordered_count += 1
@@ -420,9 +542,7 @@ def reorder_config(
     # Update metadata.generated_at (if present) for audit trail.
     metadata = config.get("metadata", {})
     if metadata:
-        metadata["last_reorder_at"] = time.strftime(
-            "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
-        )
+        metadata["last_reorder_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         metadata["last_reorder_stats"] = {
             "total_models": len(virtual_models),
             "reordered": reordered_count,
@@ -435,9 +555,7 @@ def reorder_config(
     if dry_run:
         log_lines.insert(1, f"DRY RUN — would rewrite {config_path}")
     else:
-        backup_path = config_path.with_suffix(
-            f".yaml.bak-{int(time.time())}"
-        )
+        backup_path = config_path.with_suffix(f".yaml.bak-{int(time.time())}")
         shutil.copy2(config_path, backup_path)
         logger.info("backed up %s -> %s", config_path, backup_path)
         with config_path.open("w") as f:
@@ -491,7 +609,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         default=DEFAULT_MAX_TTFT_MS,
         help=f"TTFT normalization ceiling in ms (default: {DEFAULT_MAX_TTFT_MS})",
     )
-    parser.add_argument("--dry-run", action="store_true", help="Print plan, don't write")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print plan, don't write"
+    )
     parser.add_argument("--verbose", "-v", action="store_true", help="Debug logging")
     parser.add_argument(
         "--use-u-formula",

--- a/tests/test_free_baseline.py
+++ b/tests/test_free_baseline.py
@@ -1,0 +1,216 @@
+"""Tests for #343 free-model baseline enforcement in reorder_chains.py.
+
+Verifies:
+- is_free_provider classifies the 4 free kinds + paid/missing correctly
+- apply_free_baseline demotes non-free entries below the free floor to slot 99
+- free entries are never demoted regardless of score
+- entries with invalid scores (< 0, insufficient samples) are not demoted
+- when no free entries have valid scores, chain is unchanged (fallback path)
+- log line per demotion matches the #343-required format
+- demotion preserves order of kept entries + extra dict keys
+
+Run: python -m pytest tests/test_free_baseline.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+_spec = importlib.util.spec_from_file_location(
+    "reorder_chains",
+    _REPO_ROOT / "scripts" / "reorder_chains.py",
+)
+assert _spec is not None and _spec.loader is not None
+reorder_chains = importlib.util.module_from_spec(_spec)
+sys.modules["reorder_chains"] = reorder_chains
+_spec.loader.exec_module(reorder_chains)
+
+from reorder_chains import (  # type: ignore
+    apply_free_baseline,
+    is_free_provider,
+)
+
+
+@dataclass
+class _Cat:
+    """Minimal stand-in for rank_models.ProviderCategory."""
+
+    name: str
+    kind: str = "paid"
+
+
+class TestIsFreeProvider(unittest.TestCase):
+    def test_free_kinds(self):
+        for kind in ("free_unlimited", "free_daily", "free_one_time", "no_key"):
+            cats = {"p": _Cat("p", kind)}
+            self.assertTrue(is_free_provider("p", cats), f"{kind} should be free")
+
+    def test_paid_is_not_free(self):
+        cats = {"p": _Cat("p", "paid")}
+        self.assertFalse(is_free_provider("p", cats))
+
+    def test_missing_provider_not_free(self):
+        self.assertFalse(is_free_provider("ghost", {}))
+
+    def test_unknown_kind_not_free(self):
+        cats = {"p": _Cat("p", "unknown_kind")}
+        self.assertFalse(is_free_provider("p", cats))
+
+
+class TestApplyFreeBaseline(unittest.TestCase):
+    def _chain(self, entries: List[Tuple[str, str, int]]) -> List[Dict]:
+        return [{"provider": p, "model": m, "priority": pr} for p, m, pr in entries]
+
+    def test_demotes_non_free_below_floor(self):
+        # free floor = min(0.80, 0.50) = 0.50. paid at 0.30 < floor -> demote.
+        chain = self._chain(
+            [("groq", "good", 1), ("nvidia", "ok", 2), ("openai", "bad", 3)]
+        )
+        cats = {
+            "groq": _Cat("groq", "free_unlimited"),
+            "nvidia": _Cat("nvidia", "free_unlimited"),
+            "openai": _Cat("openai", "paid"),
+        }
+        scores = {
+            ("groq", "good"): 0.80,
+            ("nvidia", "ok"): 0.50,
+            ("openai", "bad"): 0.30,
+        }
+        new_chain, logs = apply_free_baseline(chain, scores, cats)
+        # openai demoted to slot 99; groq + nvidia keep order at 1, 2
+        self.assertEqual(new_chain[0]["provider"], "groq")
+        self.assertEqual(new_chain[0]["priority"], 1)
+        self.assertEqual(new_chain[1]["provider"], "nvidia")
+        self.assertEqual(new_chain[1]["priority"], 2)
+        self.assertEqual(new_chain[2]["provider"], "openai")
+        self.assertEqual(new_chain[2]["priority"], 99)
+        self.assertEqual(len(logs), 1)
+        self.assertIn("[BASELINE]", logs[0])
+        self.assertIn("openai/bad", logs[0])
+        self.assertIn("demoted below free baseline", logs[0])
+
+    def test_free_entry_never_demoted_even_if_lowest(self):
+        # free entry has the lowest score but must not be demoted.
+        chain = self._chain([("groq", "low", 1), ("openai", "high", 2)])
+        cats = {
+            "groq": _Cat("groq", "free_unlimited"),
+            "openai": _Cat("openai", "paid"),
+        }
+        scores = {("groq", "low"): 0.20, ("openai", "high"): 0.90}
+        new_chain, logs = apply_free_baseline(chain, scores, cats)
+        # floor = 0.20; openai 0.90 >= floor -> not demoted; groq kept.
+        # No demotions -> chain returned unchanged.
+        self.assertEqual(len(logs), 0)
+        self.assertEqual([c["provider"] for c in new_chain], ["groq", "openai"])
+
+    def test_invalid_scores_not_demoted(self):
+        # score = -1 (insufficient samples) must NOT be demoted even if
+        # non-free and below floor.
+        chain = self._chain([("groq", "free1", 1), ("openai", "unknown", 2)])
+        cats = {
+            "groq": _Cat("groq", "free_unlimited"),
+            "openai": _Cat("openai", "paid"),
+        }
+        scores = {("groq", "free1"): 0.60, ("openai", "unknown"): -1.0}
+        new_chain, logs = apply_free_baseline(chain, scores, cats)
+        self.assertEqual(len(logs), 0)
+        # openai has invalid score -> not demoted, stays in ranked order
+        self.assertEqual(new_chain[-1]["provider"], "openai")
+        self.assertNotEqual(new_chain[-1]["priority"], 99)
+
+    def test_no_free_data_returns_unchanged(self):
+        # No free providers -> fallback to current behaviour (unchanged).
+        chain = self._chain([("openai", "a", 1), ("openai", "b", 2)])
+        cats = {"openai": _Cat("openai", "paid")}
+        scores = {("openai", "a"): 0.90, ("openai", "b"): 0.10}
+        new_chain, logs = apply_free_baseline(chain, scores, cats)
+        self.assertEqual(len(logs), 0)
+        self.assertEqual([c["priority"] for c in new_chain], [1, 2])
+
+    def test_no_free_valid_scores_returns_unchanged(self):
+        # Free providers exist but all have invalid scores -> unchanged.
+        chain = self._chain([("groq", "free1", 1), ("openai", "paid1", 2)])
+        cats = {
+            "groq": _Cat("groq", "free_unlimited"),
+            "openai": _Cat("openai", "paid"),
+        }
+        scores = {("groq", "free1"): -1.0, ("openai", "paid1"): 0.90}
+        new_chain, logs = apply_free_baseline(chain, scores, cats)
+        self.assertEqual(len(logs), 0)
+        self.assertEqual([c["priority"] for c in new_chain], [1, 2])
+
+    def test_multiple_demotions_get_99_100_101(self):
+        chain = self._chain(
+            [
+                ("groq", "free1", 1),
+                ("openai", "bad1", 2),
+                ("openai", "bad2", 3),
+                ("openai", "bad3", 4),
+            ]
+        )
+        cats = {
+            "groq": _Cat("groq", "free_unlimited"),
+            "openai": _Cat("openai", "paid"),
+        }
+        scores = {
+            ("groq", "free1"): 0.70,
+            ("openai", "bad1"): 0.10,
+            ("openai", "bad2"): 0.20,
+            ("openai", "bad3"): 0.30,
+        }
+        new_chain, logs = apply_free_baseline(chain, scores, cats)
+        # floor = 0.70; all 3 openai entries below -> demoted to 99, 100, 101
+        demoted = [c for c in new_chain if c["provider"] == "openai"]
+        self.assertEqual([c["priority"] for c in demoted], [99, 100, 101])
+        self.assertEqual(len(logs), 3)
+        kept = [c for c in new_chain if c["provider"] == "groq"]
+        self.assertEqual(kept[0]["priority"], 1)
+
+    def test_preserves_extra_keys(self):
+        chain = [
+            {"provider": "groq", "model": "f", "priority": 1, "notes": "keep"},
+            {
+                "provider": "openai",
+                "model": "p",
+                "priority": 2,
+                "capabilities": {"tools": True},
+            },
+        ]
+        cats = {
+            "groq": _Cat("groq", "free_unlimited"),
+            "openai": _Cat("openai", "paid"),
+        }
+        scores = {("groq", "f"): 0.80, ("openai", "p"): 0.10}
+        new_chain, _ = apply_free_baseline(chain, scores, cats)
+        free_entry = next(c for c in new_chain if c["provider"] == "groq")
+        paid_entry = next(c for c in new_chain if c["provider"] == "openai")
+        self.assertEqual(free_entry["notes"], "keep")
+        self.assertEqual(paid_entry["capabilities"], {"tools": True})
+
+    def test_baseline_floor_min_argument(self):
+        # floor = max(baseline, baseline_floor_min). baseline=0.50 but
+        # floor_min=0.60 -> paid at 0.55 (< 0.60) demoted despite > baseline.
+        chain = self._chain([("groq", "free1", 1), ("openai", "mid", 2)])
+        cats = {
+            "groq": _Cat("groq", "free_unlimited"),
+            "openai": _Cat("openai", "paid"),
+        }
+        scores = {("groq", "free1"): 0.50, ("openai", "mid"): 0.55}
+        new_chain, logs = apply_free_baseline(
+            chain, scores, cats, baseline_floor_min=0.60
+        )
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(new_chain[-1]["provider"], "openai")
+        self.assertEqual(new_chain[-1]["priority"], 99)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Enforce the free-model baseline during `reorder_chains.py`: any non-free provider+model scoring worse than the worst available free model is demoted to a last-resort priority slot (99, 100, ...).

Closes #343.

## Why

Per DESIGN.md: free models set the quality floor. Only non-free models better than the worst available free model should appear in priority slots. This stops a weak paid model from sitting above a strong free one after telemetry-driven reorder. Free-tier-only gateway must not spend a paid/RPM-scarce slot on something a free model already beats.

## Changes

`scripts/reorder_chains.py` (+133/-13):
- **`is_free_provider(provider, categories)`** — duck-types `ProviderCategory.kind`; free kinds = `free_unlimited`, `free_daily`, `free_one_time`, `no_key`. Paid/unknown/missing → not free.
- **`apply_free_baseline(chain, score_lookup, categories, baseline_floor_min=0.0)`** — post-ranking step. Baseline = `min(valid free scores)`; floor = `max(baseline, baseline_floor_min)`. Non-free entries with a valid (`>= 0`) score strictly below floor → priority slot 99+. Free entries never demoted. Entries with invalid scores (`< 0`, insufficient samples) never demoted (don't penalise untested models). When no free entries have valid scores → chain unchanged (current-behaviour fallback per #343 acceptance criterion 4).
- **Composite mode now loads provider categories** (`rank_models.load_provider_categories()`) — needed for the baseline filter in both modes. Graceful skip if provider DB missing (`cats={}` → baseline skipped, existing behaviour preserved).
- **Per-chain `score_lookup` built in `reorder_config`**: from `RankReason.score` for U-formula, from recomputed `compute_composite` for composite mode.
- **Log line per demotion**: `[BASELINE] {provider}/{model} score=X demoted below free baseline Y` (matches #343 acceptance criterion 5).

`tests/test_free_baseline.py` (new, 12 tests):
- `is_free_provider`: 4 free kinds → True; paid → False; missing → False; unknown kind → False.
- `apply_free_baseline`: demotes non-free below floor to slot 99; free entry never demoted even if lowest; invalid scores not demoted; no free data → unchanged; no free valid scores → unchanged; multiple demotions → 99/100/101; extra dict keys preserved; `baseline_floor_min` argument raises the floor above the raw baseline.

## Verification

- `python3 -m unittest tests.test_free_baseline tests.test_reorder_chains` → **32 tests pass** (12 new + 20 existing, no regressions).
- `python3 -m py_compile scripts/reorder_chains.py` → OK.
- No new lines over 88 chars (black limit). Pre-existing long lines unchanged.
- Secret scan (API keys/tokens, private IPs, hardcoded creds) → clean. gitleaks pre-push hook → 0 leaks.

## Acceptance Criteria

- [x] reorder_chains.py asks for free-tier baseline scores at start (loads provider categories, computes baseline per chain)
- [x] Any non-free provider+model scoring below max(baseline_score, 0) moved to priority slot 99 (last-resort)
- [x] Free-tier baseline computed live, not cached; refresh on every reorder (baseline recomputed per chain per run)
- [x] Exception path: when no free models have data, fall back to current behaviour (returns chain unchanged)
- [x] Log line per demotion: `[BASELINE] {provider}/{model} score=X demoted below free baseline Y`
- [x] Unit tests for the filter logic + last-resort demotion (12 tests)

## Notes

- The `src/proxy_app/leadboards/llm_aggregated_leaderboard.csv` path referenced in #343's body is stale (does not exist on `origin/main`). Benchmark data lives in `llm-leaderboard-aggregate/db/models.db`, already loaded by `rank_models.load_benchmark_scores()`. Free classification comes from `llm-provider-manager/llm_providers.db` via `load_provider_categories()`. No new data source needed.
- Does not introduce new free-tier providers (stays in #256 territory per #343 constraints).
- VPS not touched (has uncommitted config). VPS pulls when ready.
