### PR TITLE
fix(config): remove 9 pseudo-providers, re-enable gemini, mark 3 dead (#345)

### DIFF
--- a/config/router_config.yaml
+++ b/config/router_config.yaml
@@ -54,7 +54,7 @@ providers:
     free_tier: true
     no_api_key_required: true
   gemini:
-    enabled: false
+    enabled: true
     env_var: GEMINI_API_KEY
     base_url: https://generativelanguage.googleapis.com/v1beta
     free_tier: true
@@ -66,7 +66,6 @@ providers:
     - gemma-3-27b-it
     - gemini-1.5-flash
     - gemini-1.5-pro
-    _auto_disabled_reason: HTTP 404
   cerebras:
     enabled: true
     env_var: CEREBRAS_API_KEY
@@ -221,7 +220,8 @@ providers:
     - minimax-m2.7
     - mimo-v2-pro
     - mimo-v2-omni
-    _auto_disabled_reason: Request URL is missing an 'http://' or 'https://' protocol.
+    _dead: true
+    _dead_reason: Railway app down — all routes return 404 JSON status page (audit 2026-07-03). Not recoverable.
   brave_search:
     enabled: true
     env_var: BRAVE_API_KEY
@@ -244,195 +244,6 @@ providers:
     env_var: JINA_API_KEY
     free_tier: true
     no_api_key_required: true
-  router/best-coding:
-    description: Best for coding tasks
-    candidates:
-    - provider: groq
-      model: llama-3.3-70b-versatile
-      priority: 1
-      capabilities:
-      - tools
-      - function_calling
-    - provider: gemini
-      model: gemini-3-pro
-      priority: 2
-      capabilities:
-      - tools
-      - function_calling
-      fallback_only: true
-    - provider: g4f
-      model: gpt-4
-      priority: 3
-      fallback_only: true
-  router/best-reasoning:
-    description: Best for reasoning and analysis
-    candidates:
-    - provider: groq
-      model: llama-3.3-70b-versatile
-      priority: 1
-      capabilities:
-      - reasoning
-    - provider: gemini
-      model: gemini-3-pro
-      priority: 2
-      capabilities:
-      - reasoning
-      - long_context
-      fallback_only: true
-  router/best-research:
-    description: Best for research with search capabilities
-    candidates:
-    - provider: gemini
-      model: gemini-3-pro
-      priority: 1
-      capabilities:
-      - tools
-      - long_context
-      search_enabled: true
-    - provider: groq
-      model: llama-3.3-70b-versatile
-      priority: 2
-      capabilities:
-      - tools
-      search_enabled: true
-      fallback_only: true
-  router/best-chat:
-    description: Best for general chat
-    candidates:
-    - provider: groq
-      model: llama-3.1-8b-instant
-      priority: 1
-      capabilities:
-      - fast
-    - provider: gemini
-      model: gemini-2.5-flash
-      priority: 2
-      capabilities:
-      - fast
-      fallback_only: true
-    - provider: g4f
-      model: gpt-3.5-turbo
-      priority: 3
-      fallback_only: true
-  router/best-coding-moe:
-    description: Committee/MoE mode for coding
-    moe_mode: true
-    max_experts: 3
-    aggregator_model: groq/llama-3.3-70b-versatile
-    candidates:
-    - provider: groq
-      model: llama-3.3-70b-versatile
-      role: expert-architect
-    - provider: gemini
-      model: gemini-3-pro
-      role: expert-secure-coding
-    - provider: groq
-      model: mixtral-8x7b-32768
-      role: expert-optimization
-      fallback_only: true
-  coding-smart:
-    description: Best models for complex coding tasks (Free tier)
-    candidates:
-    - provider: groq
-      model: llama-3.3-70b-versatile
-      priority: 1
-      capabilities:
-      - tools
-      - function_calling
-      - reasoning
-    - provider: cerebras
-      model: llama-3.3-70b
-      priority: 2
-      capabilities:
-      - tools
-      - function_calling
-      - reasoning
-    - provider: gemini
-      model: gemini-2.5-flash
-      priority: 3
-      capabilities:
-      - tools
-      - function_calling
-      - fast
-    - provider: gemini
-      model: gemini-2.5-pro
-      priority: 4
-      capabilities:
-      - tools
-      - function_calling
-      - reasoning
-      fallback_only: true
-    - provider: g4f_nvidia
-      model: meta/llama-3.3-70b-instruct
-      priority: 5
-      capabilities:
-      - tools
-      - function_calling
-      fallback_only: true
-    - provider: g4f_nvidia
-      model: deepseek-ai/deepseek-v3.1
-      priority: 6
-      capabilities:
-      - tools
-      - function_calling
-      fallback_only: true
-    - provider: g4f
-      model: gpt-4
-      priority: 7
-      fallback_only: true
-  coding-fast:
-    description: Fastest models for quick coding tasks (Free tier)
-    candidates:
-    - provider: groq
-      model: llama-3.1-8b-instant
-      priority: 1
-      capabilities:
-      - tools
-      - function_calling
-      - fast
-    - provider: gemini
-      model: gemini-2.5-flash
-      priority: 2
-      fallback_only: true
-    - provider: g4f
-      model: gpt-4
-      priority: 3
-      fallback_only: true
-  chat-smart:
-    description: High intelligence chat models (Free tier)
-    candidates:
-    - provider: groq
-      model: llama-3.3-70b-versatile
-      priority: 1
-      capabilities:
-      - tools
-      - function_calling
-      - reasoning
-    - provider: gemini
-      model: gemini-1.5-pro
-      priority: 2
-      fallback_only: true
-    - provider: g4f
-      model: gpt-4
-      priority: 3
-      fallback_only: true
-  chat-fast:
-    description: Low latency chat models (Free tier)
-    candidates:
-    - provider: groq
-      model: llama-3.1-8b-instant
-      priority: 1
-      capabilities:
-      - fast
-      - tools
-    - provider: gemini
-      model: gemini-2.5-flash
-      priority: 2
-      fallback_only: true
-    - provider: g4f
-      model: gpt-3.5-turbo
-      priority: 3
-      fallback_only: true
   g4f_nvidia:
     enabled: true
     env_var: G4F_NVIDIA_API_KEY
@@ -635,7 +446,8 @@ providers:
     free_tier: true
     free_tier_models:
     - auto
-    _auto_disabled_reason: HTTP 404
+    _dead: true
+    _dead_reason: No OpenAI-compat API at base_url — all /v1 routes 404 (nginx), root 200 only (audit 2026-07-03). Base URL wrong or API removed.
   xinjianya:
     enabled: false
     env_var: XINJIANYA_API_KEY
@@ -652,7 +464,8 @@ providers:
     - z-ai/glm5
     - moonshotai/kimi-k2.5
     - minimaxai/minimax-m2.5
-    _auto_disabled_reason: '[Errno -2] Name or service not known'
+    _dead: true
+    _dead_reason: DNS fail — Name or service not known (audit 2026-07-03). Domain dead.
   freemodel:
     enabled: true
     env_var: FREEMODEL_API_KEY


### PR DESCRIPTION
## #345 Audit Report — Provider Re-enable / Removal

Audited all 8 disabled providers in `config/router_config.yaml` (origin/main) + 9 pseudo-provider entries. SSH'd to gateway-40 to check `.env` key presence + probe endpoints (authed + unauthed).

### Spec correction
Issue body said 41 providers / 24 enabled / 17 disabled. **Actual state (origin/main):** 41 entries under `providers:` = **32 real + 9 pseudo**. 33 enabled / 8 disabled. All 8 disabled were real providers; the 9 pseudo-providers (router/best-* ×5, coding-*/chat-* ×4) were enabled-but-misclassified router-model defs that the loader already skips (`_SKIP_PREFIXES=("router/",)` + `if "candidates" in pcfg or "description" in pcfg: continue` in `router_integration.py:54-65`). coding-*/chat-* were also **duplicated** in the top-level `router_models:` block (the real source for virtual models — `router_core.py:1113`).

### Bucket 1 — Re-enabled (1)
| provider | key in .env | authed probe | result |
|---|---|---|---|
| gemini | GEMINI_API_KEY ✓ | `GET /v1beta/models?key=$KEY` → 200, 50 models | **enabled:true, dropped `_auto_disabled_reason`** |

The HTTP 404 auto-disable was the bare `/v1beta` root returning 404 (no route at root); real endpoints work.

### Bucket 2 — Key-required, left disabled (4)
| provider | missing env var | base_url | notes |
|---|---|---|---|
| kilo | `KILO_API_KEY` | https://api.kilo.ai/v1 | KILOCLOUD_* exists in .env but is a different provider. 16 free models available once key added. |
| sambanova | `SAMBANOVA_API_KEY` | https://api.sambanova.ai/v1 | 8 free models (DeepSeek-V3.2, Qwen3-235B, Llama-4-Maverick). |
| github-models | `GITHUB_MODELS_API_KEY` | https://models.inference.ai.azure.com | 8 free models (grok-3-mini, deepseek-r1/v3, phi-4). |
| cloudflare | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` | https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/run/ | 6 @cf/* models. Needs account ID for URL templating. |

No keys invented. Add the env var to `.env` on the VPS to enable.

### Bucket 3 — Dead, marked `_dead: true` (3)
| provider | reason | audit detail |
|---|---|---|
| wiwi | Railway app down | All routes (`/`, `/v1`, `/v1/models`, `/v1/chat/completions`) return 404 JSON status page `{status,code,message,request_id}`. Not recoverable. |
| antigravity | No OpenAI-compat API at base_url | Root `/` → 200, but all `/v1*` routes → 404 (nginx). Base URL wrong or API removed. |
| xinjianya | DNS fail | `api.xinjianya.top` → `Name or service not known`. Domain dead. |

Marked with `_dead: true` + `_dead_reason:` (audit timestamp 2026-07-03) instead of deleting, to preserve audit trail and prevent auto-re-enable. xinjianya was the only non-free disabled provider.

### Pseudo-providers removed from `providers:` (9)
Removed 9 entries (189 lines) that were router-model definitions misclassified as providers:
- `router/best-coding`, `router/best-reasoning`, `router/best-research`, `router/best-chat`, `router/best-coding-moe` — legacy router-model aliases. **Not present in `router_models:` block**, advertised in `enhanced_proxy.py:103-115` fallback list (error-path only) + smoke tests, but would fail to route (no candidates loaded). Broken legacy — removed.
- `coding-smart`, `coding-fast`, `chat-smart`, `chat-fast` — **duplicated** in `router_models:` block (L749-939) which is the real source (`router_core.py:1113 self.virtual_models = self.config.get("router_models", {})`). Removed the `providers:` duplicates.

No code references the removed entries as providers — `router_integration.py` skip logic already handled them, and `enhanced_proxy.py` hardcodes the model IDs (not dict lookups).

### Counts (after)
- `providers:` block: 32 entries (was 41) — 25 enabled / 7 disabled (was 33/8).
- `router_models:` block: 5 entries (unchanged) — coding-smart, coding-fast, chat-smart, chat-fast, swiftrouter.
- Net: +1 real provider enabled (gemini), -9 dead config weight, 3 dead marked clearly.

### Acceptance criteria
- [x] Audit table per disabled provider (reason/key/endpoint/recovery) — see buckets above
- [x] Remove pseudo-providers from `providers:` section — 9 removed
- [x] Re-enable real providers with working key+endpoint — gemini re-enabled
- [x] List key-missing env vars — 4 listed in Bucket 2
- [x] Post report comment with 3 buckets — this comment
- [x] Enabled count up + disabled down — enabled 33→25 among real providers (pseudo removed), but real-enabled went 24→25 (+gemini); disabled real stayed 8→7 net (3 marked dead, but still disabled); overall providers 41→32

PR: #TBD
