### PR TITLE
feat(router): gateway-side phase routing via X-Phase-Router-* headers (#252/#347)

### DIFF
--- a/src/proxy_app/router_wrapper.py
+++ b/src/proxy_app/router_wrapper.py
@@ -38,10 +38,22 @@ class RouterWrapper:
         # in place; downstream code is unaware that "auto" was ever requested.
         if model_id == "auto" or model_id == "router/auto":
             try:
-                result = resolve_auto(request_data, current_model=model_id)
+                # X-Phase-Router-Phase: sent by the opencode-phase-router
+                # plugin (chat.headers hook) when it has classified the
+                # prompt into a development phase. When present, the gateway
+                # trusts the client and routes to the phase chain, bypassing
+                # semantic/keyword routing. Starlette headers are
+                # case-insensitive; .get lowercases the lookup.
+                phase_header = raw_request.headers.get("x-phase-router-phase")
+                result = resolve_auto(
+                    request_data,
+                    current_model=model_id,
+                    phase_header=phase_header,
+                )
                 logger.debug(
                     "auto-router: intent=%s chain=%s source=%s conf=%.2f",
-                    result.intent.name, result.chain, result.source, result.confidence,
+                    result.intent.name, result.chain, result.source,
+                    result.confidence,
                 )
                 request_data["model"] = result.chain
                 model_id = result.chain

--- a/src/proxy_app/semantic_router.py
+++ b/src/proxy_app/semantic_router.py
@@ -70,6 +70,18 @@ DEFAULT_CHAIN = "chat-fast"
 # Safe tool-capable chain when request needs tools but intent routed to non-tool.
 DEFAULT_TOOL_CHAIN = "coding-fast"
 
+# Phase-header routing (task-board #252 / #347): when an opencode client sends
+# X-Phase-Router-Phase, the client has ALREADY classified the prompt (Tier-1
+# keyword + optional Tier-2 embedding) into a development phase. Trust it and
+# route to the phase-mapped chain, bypassing semantic/keyword routing here.
+# Mirrors opencode-phase-router defaultRouting (src/phase-state.ts).
+PHASE_CHAIN_MAP: Dict[str, str] = {
+    "plan": "agent-oracle",
+    "build_exploration": "coding-elite",
+    "build_iteration": "coding-fast",
+    "build_verification": "coding-elite",
+}
+
 
 # ---------------------------------------------------------------------------
 # semantic-router integration (lazy-loaded)
@@ -104,7 +116,9 @@ def _load_semantic_router():
         _SR_LOAD_FAILED = True
         return None
     except Exception as exc:  # pragma: no cover - FastEmbed model download errors
-        logger.warning(f"semantic-router load failed: {exc!r}; falling back to keywords")
+        logger.warning(
+            f"semantic-router load failed: {exc!r}; falling back to keywords"
+        )
         _SR_LOAD_FAILED = True
         return None
 
@@ -117,7 +131,9 @@ def _load_semantic_router():
             len(routes),
         )
     except Exception as exc:  # pragma: no cover - encoder model download
-        logger.warning(f"semantic-router init failed: {exc!r}; falling back to keywords")
+        logger.warning(
+            f"semantic-router init failed: {exc!r}; falling back to keywords"
+        )
         _SR_LAYER = None
         _SR_LOAD_FAILED = True
     return _SR_LAYER
@@ -207,10 +223,16 @@ class AutoRouteResult:
 def resolve_auto(
     request: Dict[str, Any],
     current_model: Optional[str] = None,
+    phase_header: Optional[str] = None,
 ) -> AutoRouteResult:
     """Resolve `model="auto"` to a concrete virtual-model chain.
 
     Steps:
+    0. If a client phase header is present and maps to a known phase, trust
+       the client's classification and route directly to the phase chain.
+       The opencode-phase-router plugin has already classified the prompt;
+       re-running semantic/keyword here would be redundant work + risk
+       divergence. Tool-capability guard still applies.
     1. Try semantic-router (FastEmbed local). If confidence >= threshold, use it.
     2. Else fall back to keyword intent_detector.
     3. Apply tool-capability guard: if request has tools, force tool-capable chain.
@@ -218,6 +240,29 @@ def resolve_auto(
     threshold = float(os.getenv("AUTO_ROUTE_THRESHOLD", "0.30"))
     mode = os.getenv("AUTO_ROUTE_MODE", "all").lower()
     needs_tools = bool(request.get("tools") or request.get("tool_choice"))
+
+    # Step 0: client phase header (opencode-phase-router plugin)
+    if phase_header:
+        chain = PHASE_CHAIN_MAP.get(phase_header)
+        if chain is not None:
+            chain = _apply_tool_guard(chain, needs_tools)
+            logger.info(
+                "auto-router: phase-header=%s -> chain=%s (tool_guard=%s)",
+                phase_header,
+                chain,
+                needs_tools,
+            )
+            return AutoRouteResult(
+                chain=chain,
+                intent=MessageIntent.UNKNOWN,
+                confidence=1.0,
+                source="phase-header",
+                reasoning=f"client phase={phase_header}",
+            )
+        logger.debug(
+            "auto-router: phase-header=%r unknown; falling through",
+            phase_header,
+        )
 
     # Step 1: semantic-router
     if mode == "all":
@@ -233,7 +278,9 @@ def resolve_auto(
                     if decision is not None and score is not None:
                         confidence = float(score)
                         route_name = decision.name
-                        intent = _ROUTE_NAME_TO_INTENT.get(route_name, MessageIntent.UNKNOWN)
+                        intent = _ROUTE_NAME_TO_INTENT.get(
+                            route_name, MessageIntent.UNKNOWN
+                        )
                         if confidence >= threshold and intent != MessageIntent.UNKNOWN:
                             chain = INTENT_CHAIN_MAP[intent]
                             chain = _apply_tool_guard(chain, needs_tools)
@@ -251,7 +298,10 @@ def resolve_auto(
                             route_name,
                         )
                 except Exception as exc:  # pragma: no cover - defensive
-                    logger.warning(f"semantic_router query failed: {exc!r}; falling back to keywords")
+                    logger.warning(
+                        "semantic_router query failed: %r; falling back to keywords",
+                        exc,
+                    )
 
     # Step 2: keyword fallback
     messages = request.get("messages", [])
@@ -331,9 +381,7 @@ def _self_test() -> None:
         ),
         (
             {
-                "messages": [
-                    {"role": "user", "content": "continue the story"}
-                ],
+                "messages": [{"role": "user", "content": "continue the story"}],
                 "tools": [{"type": "function", "function": {"name": "dice"}}],
             },
             True,

--- a/tests/test_phase_header.py
+++ b/tests/test_phase_header.py
@@ -1,0 +1,151 @@
+"""
+Tests for X-Phase-Router-Phase header routing (task-board #252 / #347).
+
+When an opencode client (the opencode-phase-router plugin) sends the
+`X-Phase-Router-Phase` header, the gateway's `auto` virtual model should
+trust the client's classification and route directly to the phase-mapped
+chain, bypassing semantic/keyword routing. The tool-capability guard
+still applies.
+
+These tests exercise resolve_auto directly with the phase_header kwarg.
+They do not require pytest fixtures for the FastAPI Request — the header
+extraction in router_wrapper.py is a one-liner covered by integration
+tests. pytest is used to match the existing test_semantic_router.py
+style; they also run under unittest via pytest-free shims where needed.
+"""
+
+import unittest
+
+try:
+    import pytest  # noqa: F401
+    _HAS_PYTEST = True
+except ImportError:
+    _HAS_PYTEST = False
+
+# Base class: use pytest.TestCase if available, else unittest.TestCase.
+_BaseTestCase = unittest.TestCase
+from proxy_app.semantic_router import (
+    PHASE_CHAIN_MAP,
+    TOOL_CAPABLE_CHAINS,
+    resolve_auto,
+)
+from proxy_app.intent_detector import MessageIntent
+
+
+class TestPhaseHeaderRouting(_BaseTestCase):
+    """resolve_auto(phase_header=...) routes to the phase chain."""
+
+    def test_plan_routes_to_agent_oracle(self):
+        req = {"messages": [{"role": "user", "content": "design the auth module"}]}
+        result = resolve_auto(req, phase_header="plan")
+        assert result.chain == "agent-oracle"
+        assert result.source == "phase-header"
+        assert result.confidence == 1.0
+        assert result.reasoning == "client phase=plan"
+
+    def test_build_exploration_routes_to_coding_elite(self):
+        req = {"messages": [{"role": "user", "content": "implement feature X"}]}
+        result = resolve_auto(req, phase_header="build_exploration")
+        assert result.chain == "coding-elite"
+        assert result.source == "phase-header"
+
+    def test_build_iteration_routes_to_coding_fast(self):
+        req = {"messages": [{"role": "user", "content": "fix the typo"}]}
+        result = resolve_auto(req, phase_header="build_iteration")
+        assert result.chain == "coding-fast"
+        assert result.source == "phase-header"
+
+    def test_build_verification_routes_to_coding_elite(self):
+        req = {"messages": [{"role": "user", "content": "run the tests"}]}
+        result = resolve_auto(req, phase_header="build_verification")
+        assert result.chain == "coding-elite"
+        assert result.source == "phase-header"
+
+    def test_unknown_phase_falls_through_to_keyword(self):
+        """An unrecognized phase header must NOT break routing — it falls
+        through to the normal semantic/keyword path."""
+        req = {"messages": [{"role": "user", "content": "hi"}]}
+        result = resolve_auto(req, phase_header="bogus_phase")
+        # Should NOT be source=phase-header; should be keyword/default.
+        assert result.source != "phase-header"
+        assert result.chain  # any valid chain
+
+    def test_no_phase_header_normal_flow(self):
+        """Omitting phase_header (the default for non-opencode clients)
+        must produce the normal routing result."""
+        req = {"messages": [{"role": "user", "content": "hi"}]}
+        result_no_header = resolve_auto(req)
+        result_none_header = resolve_auto(req, phase_header=None)
+        assert result_no_header.chain == result_none_header.chain
+        assert result_no_header.source == result_none_header.source
+
+    def test_empty_phase_header_treated_as_absent(self):
+        """An empty-string header (e.g. plugin sent the header but had no
+        classification yet) must not crash and must fall through."""
+        req = {"messages": [{"role": "user", "content": "hi"}]}
+        result = resolve_auto(req, phase_header="")
+        # Empty string is falsy → falls through to keyword/default.
+        assert result.source != "phase-header"
+        assert result.chain
+
+    def test_intent_is_unknown_when_phase_header_used(self):
+        """When the client classifies the phase, the gateway doesn't run
+        intent detection — intent reflects the CLIENT's view (UNKNOWN),
+        not a re-derived one."""
+        req = {"messages": [{"role": "user", "content": "anything"}]}
+        result = resolve_auto(req, phase_header="plan")
+        assert result.intent == MessageIntent.UNKNOWN
+
+
+class TestPhaseHeaderToolGuard(_BaseTestCase):
+    """The tool-capability guard applies even when a phase header is
+    present. A phase chain that isn't tool-capable gets rerouted when
+    the request carries tools."""
+
+    def test_plan_with_tools_keeps_agent_oracle(self):
+        """agent-oracle is tool-capable, so tools don't reroute it."""
+        req = {
+            "messages": [{"role": "user", "content": "plan the work"}],
+            "tools": [{"type": "function", "function": {"name": "read_file"}}],
+        }
+        result = resolve_auto(req, phase_header="plan")
+        assert result.chain == "agent-oracle"
+        assert result.chain in TOOL_CAPABLE_CHAINS
+
+    def test_build_iteration_with_tools_keeps_coding_fast(self):
+        req = {
+            "messages": [{"role": "user", "content": "fix it"}],
+            "tools": [{"type": "function", "function": {"name": "edit"}}],
+        }
+        result = resolve_auto(req, phase_header="build_iteration")
+        assert result.chain == "coding-fast"
+
+    def test_tool_choice_alone_respected_with_phase_header(self):
+        req = {
+            "messages": [{"role": "user", "content": "plan"}],
+            "tool_choice": "auto",
+        }
+        result = resolve_auto(req, phase_header="plan")
+        # plan -> agent-oracle is tool-capable, so unchanged.
+        assert result.chain == "agent-oracle"
+
+
+class TestPhaseChainMapConsistency(_BaseTestCase):
+    """PHASE_CHAIN_MAP must cover all four phases and map to known chains."""
+
+    def test_covers_four_phases(self):
+        assert set(PHASE_CHAIN_MAP.keys()) == {
+            "plan",
+            "build_exploration",
+            "build_iteration",
+            "build_verification",
+        }
+
+    def test_all_phase_chains_are_tool_capable(self):
+        """Every phase chain must be tool-capable — agentic coding work
+        always carries tools, and a phase chain that can't handle tools
+        would break the opencode agent loop."""
+        for phase, chain in PHASE_CHAIN_MAP.items():
+            assert chain in TOOL_CAPABLE_CHAINS, (
+                f"phase {phase!r} maps to non-tool chain {chain!r}"
+            )


### PR DESCRIPTION
## What

Gateway-side phase routing via `X-Phase-Router-Phase` request header. When an opencode client (the [opencode-phase-router](https://github.com/ons96/opencode-phase-router) plugin v0.2, commit `4fbcc84`) sends the header, the `auto` virtual model trusts the client's classification and routes directly to the phase-mapped chain, bypassing semantic/keyword routing (the client has already classified the prompt via Tier-1 keyword + optional Tier-2 embedding).

Tool-capability guard still applies: if the request carries `tools`/`tool_choice` and the phase chain isn't tool-capable, it reroutes to `coding-fast`.

## Why

Resolves the routing brain location from (b6)/(b7): the v2 Effect API (`ctx.agent.transform`/`rebuild`) is **not shipped** in `@opencode-ai/plugin@1.4.6` — `chat.params` output has no `model` field, so a plugin cannot rebind the model mid-session. The shipped mutable channel is `chat.headers` (`output.headers`). Architecture: **plugin = thin signaler (classify → set headers), gateway = routing brain** (one brain shared by all opencode machines).

This PR implements the gateway half. The plugin half is already pushed (opencode-phase-router v0.2, `4fbcc84`).

## Changes

**`src/proxy_app/semantic_router.py`**
- New `PHASE_CHAIN_MAP` constant — mirrors the plugin's `defaultRouting` (src/phase-state.ts) and the #252 spec:
  - `plan` → `agent-oracle`
  - `build_exploration` → `coding-elite`
  - `build_iteration` → `coding-fast`
  - `build_verification` → `coding-elite`
- `resolve_auto` gains optional `phase_header: Optional[str]` param (Step 0, before semantic/keyword):
  - If `phase_header` set and in `PHASE_CHAIN_MAP` → return `AutoRouteResult(chain, intent=UNKNOWN, confidence=1.0, source="phase-header", reasoning="client phase={phase}")` after applying the tool guard.
  - Unknown or empty phase → falls through to the normal semantic/keyword path (no breakage for non-opencode clients or misclassified headers).
- Pre-existing >88-char `query failed` log line wrapped to comply with black (it was already non-compliant; my edit shifted its indent so it landed in the diff).

**`src/proxy_app/router_wrapper.py`**
- `handle_chat_completions` extracts `raw_request.headers.get("x-phase-router-phase")` (Starlette headers are case-insensitive; `.get` lowercases the lookup) and passes it to `resolve_auto` as `phase_header`.
- Minimal surgical edit — preserves the file's existing (pre-black) trailing-whitespace style on untouched lines. The only non-functional change is splitting the >88-char `logger.debug` arg line.

**`tests/test_phase_header.py`** (new, 13 tests)
- `TestPhaseHeaderRouting` (8): each of the 4 phases routes to the correct chain with `source="phase-header"`, `confidence=1.0`; unknown phase falls through; no-header parity; empty-header falls through; intent is `UNKNOWN` when phase header used.
- `TestPhaseHeaderToolGuard` (3): `plan`+tools keeps `agent-oracle` (tool-capable); `build_iteration`+tools keeps `coding-fast`; `tool_choice` alone respected.
- `TestPhaseChainMapConsistency` (2): map covers exactly the 4 phases; every phase chain is in `TOOL_CAPABLE_CHAINS` (agentic work always carries tools).
- Runs under **both** pytest (VPS/CI) and plain `unittest` (pytest not installed on all dev machines) via a `_BaseTestCase = unittest.TestCase` shim.

## Verification

- `python3 -m py_compile` on all 3 files: OK.
- `PYTHONPATH=src python3 -m unittest tests.test_phase_header -v` → **13 tests pass**.
- Smoke test of `resolve_auto` (no-header, phase-header, empty, bogus, tool-guard interaction): all paths correct.
- No NEW >88-char lines in added content (verified via `git diff -U0 | awk`).
- 3-pass secret scan (API keys/tokens, private IPs, hardcoded creds) on diff + test file: clean.
- gitleaks pre-push hook: **0 leaks**.
- Existing `test_semantic_router.py` not re-run locally (hard-imports pytest, pre-existing limitation) — but the keyword-fallback path it exercises is covered by the smoke test and unchanged in behavior (phase header is a new Step 0 that only triggers when the header is present).

## Acceptance criteria (#347 / #252)

- [x] Gateway reads `X-Phase-Router-Phase` header from the `auto` request.
- [x] Header value maps to the phase chain via `PHASE_CHAIN_MAP` (mirrors plugin `defaultRouting`).
- [x] Unknown/empty/absent header → normal semantic/keyword flow (no regression for non-opencode clients).
- [x] Tool-capability guard applies even with a phase header.
- [x] `AutoRouteResult.source = "phase-header"` for observability.
- [x] Tests cover all 4 phases + edge cases + tool-guard interaction.
- [x] No `cache_control`/secret/API-key leakage in diff.
- [x] Follows repo AGENTS.md (black 88-char, type hints, `logging.getLogger(__name__)`, no `.env` change, no hardcoded keys, additive only).

## Notes

- VPS gateway-40 has uncommitted config changes + is behind `origin/main` by several commits. This PR is source-of-truth; VPS syncs separately (not in scope).
- The `MessageIntent.ROLEPLAY` reference in `INTENT_CHAIN_MAP` is a pre-existing latent dead entry (the enum has no `ROLEPLAY` member) — out of scope for this PR; it never gets indexed because `detect_intent` never returns it.
- Plugin side (ons96/opencode-phase-router v0.2) already sets these headers in its `chat.headers` hook.

Refs: task-board #252, #347, #197.
