### PR TITLE
feat(scoring): 80/15/5 weights + SWE thresholds + free baseline (#341)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,12 +20,12 @@ Use when user wants "best overall" for a task (virtual models)
 
 **Score Formula:**
 ```
-Score = (AgenticScore × 0.60) + (TPS_Score × 0.30) + (AvailabilityScore × 0.10)
+Score = (AgenticScore × 0.80) + (TPS_Score × 0.15) + (AvailabilityScore × 0.05)
 ```
 
 **Components:**
 
-1. **AgenticScore (60% weight)**
+1. **AgenticScore (80% weight)**
    - Source: SWE-bench / HumanEval benchmark scores
    - File: `config/model_rankings.yaml`
    - Range: 0-100 (normalized to 0-1 for formula)
@@ -34,7 +34,7 @@ Score = (AgenticScore × 0.60) + (TPS_Score × 0.30) + (AvailabilityScore × 0.1
      - Gemini 3 Pro: 74.2 → 0.742
      - GPT-5.2: 71.8 → 0.718
 
-2. **TPS_Score (30% weight)**
+2. **TPS_Score (15% weight)**
    - Source: Real telemetry measurement (tokens_per_second)
    - Calculation: measured_TPS / max_observed_TPS
    - Range: 0-1
@@ -42,13 +42,19 @@ Score = (AgenticScore × 0.60) + (TPS_Score × 0.30) + (AvailabilityScore × 0.1
      - Groq: 1050 TPS / 3000 max = 0.35
      - Cerebras: 2500 TPS / 3000 max = 0.83
 
-3. **AvailabilityScore (10% weight)**
+3. **AvailabilityScore (5% weight)**
    - Source: Health monitoring + rate limit status
    - Calculation: (1 - failure_rate) × (1 - rate_limit_penalty)
    - Range: 0-1
    - Example:
      - Healthy, no rate limits: (1-0.02) × (1-0) = 0.98
      - Rate limited: (1-0.02) × (1-1) = 0.0
+
+**SWE-bench Thresholds (per #341):**
+- coding-elite: min 70.0 SWE-bench (below = last-resort slot)
+- coding-smart: min 65.0 SWE-bench (below = last-resort slot)
+- coding-fast / chat-*: no SWE threshold
+- Free-model baseline: models worse than worst free model excluded entirely
 
 **Example Calculation:**
 ```
@@ -57,18 +63,18 @@ Groq/llama-3.3-70b-versatile:
   TPS_Score: 0.35 (1050/3000)
   AvailabilityScore: 0.98 (2% failure, no rate limits)
 
-Score = (0.652 × 0.6) + (0.35 × 0.3) + (0.98 × 0.10)
-     = 0.3912 + 0.105 + 0.098
-     = 0.594
+Score = (0.652 × 0.80) + (0.35 × 0.15) + (0.98 × 0.05)
+      = 0.5216 + 0.0525 + 0.049
+      = 0.623
 
 Cerebras/llama-3.3-70b:
   AgenticScore: 0.652
   TPS_Score: 0.83 (2500/3000)
   AvailabilityScore: 0.99
 
-Score = (0.652 × 0.6) + (0.83 × 0.3) + (0.99 × 0.10)
-     = 0.3912 + 0.249 + 0.099
-     = 0.740 ✅ HIGHER - would be tried first
+Score = (0.652 × 0.80) + (0.83 × 0.15) + (0.99 × 0.05)
+      = 0.5216 + 0.1245 + 0.0495
+      = 0.696 ✅ HIGHER - would be tried first
 ```
 
 ### Specific Models (gemini-3-pro, gpt-4o, gpt-4, etc.)
@@ -166,7 +172,7 @@ Provider+Model is **SKIPPED** if ANY of these are true:
    - Filter out: rate-limited, unhealthy, down providers
 
 3. Calculate score for each valid combination
-   - Use: Score = Agentic(60%) + TPS(30%) + Availability(10%)
+   - Use: Score = Agentic(80%) + TPS(15%) + Availability(5%)
    - Sort by score descending
 
 4. Attempt requests in order
@@ -288,9 +294,9 @@ virtual_models:
 scoring:
   virtual_models:
     weights:
-      agentic_score: 0.60
-      tps_score: 0.30
-      availability_score: 0.10
+      agentic_score: 0.80
+      tps_score: 0.15
+      availability_score: 0.05
 
   specific_models:
     weights:

--- a/config/scoring_config.yaml
+++ b/config/scoring_config.yaml
@@ -4,11 +4,11 @@
 scoring:
   virtual_models:
     name: "Virtual Models (coding-elite, chat-smart, etc.)"
-    description: "Virtual models use Agentic(70%) + TPS(30%), Availability is yes/no filter"
+    description: "Virtual models use Agentic(80%) + TPS(15%) + Availability(5%) per DESIGN.md Quality-First"
     weights:
-      agentic_score: 0.70
-      tps_score: 0.30
-      availability_score: 0.0
+      agentic_score: 0.80
+      tps_score: 0.15
+      availability_score: 0.05
     use_case: "For agentic coding and general chat - quality first, then speed"
 
   specific_models:

--- a/scripts/generate_virtual_models.py
+++ b/scripts/generate_virtual_models.py
@@ -28,22 +28,23 @@ CONFIG_DIR = PROJECT_ROOT / "config"
 # 2. SWE-bench + Agentic coding get highest combined weight for coding
 # 3. Logarithmic TPS scaling prevents ultra-fast from dominating
 WEIGHTS = {
+    # ponytail: 80/15/5 split (agentic_family/tps/hallucination) per DESIGN.md #341
     "coding-elite": {
         # Agentic coding benchmarks dominate - actual measure of ability
-        "swe_bench": 0.35,  # Primary: SWE-bench (most reliable)
-        "agentic": 0.30,  # Secondary: Agentic coding composite
-        "livecodebench": 0.18,  # LiveBench coding
-        "humaneval": 0.12,  # Classic coding benchmark
-        "tps": 0.03,  # Minimal speed weight (was 0.10)
-        "hallucination_penalty": 0.02,
+        "swe_bench": 0.30,  # Primary: SWE-bench (most reliable)
+        "agentic": 0.25,  # Secondary: Agentic coding composite
+        "livecodebench": 0.15,  # LiveBench coding
+        "humaneval": 0.10,  # Classic coding benchmark
+        "tps": 0.15,
+        "hallucination_penalty": 0.05,
     },
     "coding-smart": {
-        "swe_bench": 0.30,
-        "agentic": 0.25,
+        "swe_bench": 0.28,
+        "agentic": 0.22,
         "livecodebench": 0.15,
-        "humaneval": 0.12,
-        "tps": 0.08,  # Slightly higher for "smart but reasonable"
-        "hallucination_penalty": 0.10,
+        "humaneval": 0.15,
+        "tps": 0.15,
+        "hallucination_penalty": 0.05,
     },
     "coding-fast": {
         "swe_bench": 0.22,  # Still need quality floor

--- a/src/rotator_library/scoring_engine.py
+++ b/src/rotator_library/scoring_engine.py
@@ -35,58 +35,77 @@ class DynamicScoringEngine:
     providers are skipped at runtime instead.
     """
 
+    # ponytail: 80/15/5 per DESIGN.md #341 (agentic/tps/availability).
+    # Hallucination is a subtractive penalty, NOT part of the 80/15/5 split,
+    # so weight sums below exclude it. Availability IS now scored (5%).
     CATEGORY_WEIGHTS = {
         "coding-elite": {
-            "agentic": 0.75,
+            "agentic": 0.80,
             "tps": 0.15,
+            "availability": 0.05,
             "hallucination_penalty": 0.10,
         },
         "coding-smart": {
-            "agentic": 0.65,
-            "tps": 0.20,
+            "agentic": 0.80,
+            "tps": 0.15,
+            "availability": 0.05,
             "hallucination_penalty": 0.15,
         },
         "coding-fast": {
-            "agentic": 0.30,
-            "tps": 0.55,
+            "agentic": 0.80,
+            "tps": 0.15,
+            "availability": 0.05,
             "hallucination_penalty": 0.15,
         },
         "chat-elite": {
             "intelligence": 0.80,
+            "tps": 0.15,
+            "availability": 0.05,
             "hallucination_penalty": 0.20,
         },
         "chat-smart": {
-            "intelligence": 0.50,
-            "tps": 0.30,
+            "intelligence": 0.80,
+            "tps": 0.15,
+            "availability": 0.05,
             "hallucination_penalty": 0.20,
         },
         "chat-fast": {
-            "tps": 0.60,
-            "intelligence": 0.20,
+            "intelligence": 0.80,
+            "tps": 0.15,
+            "availability": 0.05,
             "hallucination_penalty": 0.20,
         },
     }
 
     CODING_WEIGHTS = {
-        "agentic": 0.75,
+        "agentic": 0.80,
         "tps": 0.15,
+        "availability": 0.05,
         "hallucination_penalty": 0.10,
     }
 
     CHAT_WEIGHTS = {
-        "intelligence": 0.60,
-        "tps": 0.25,
+        "intelligence": 0.80,
+        "tps": 0.15,
+        "availability": 0.05,
         "hallucination_penalty": 0.15,
     }
 
+    # ponytail: SWE-bench floors per #341. Below-floor models demoted to
+    # last-resort priority slot, NOT excluded (chain stays resilient).
     THRESHOLDS = {
-        "coding-elite": 75.0,
+        "coding-elite": 70.0,
         "coding-smart": 65.0,
-        "coding-fast": 40.0,
+        "coding-fast": 0.0,  # fast tier: no SWE floor, speed-first
         "chat-elite": 0.0,
         "chat-smart": 0.0,
         "chat-fast": 0.0,
     }
+
+    # ponytail: free-model baseline = worst available free model's agentic
+    # score. Models below baseline excluded from coding-* chains entirely.
+    # Upgraded to per-tier if FREEDOT_BASELINES set, else computed at load.
+    FREE_BASELINE_FLOOR = 30.0  # hard floor; computed baseline >= this
 
     def __init__(
         self,
@@ -116,11 +135,43 @@ class DynamicScoringEngine:
 
             self._rankings_cache = rankings
             self._last_refresh = time.time()
+            self._compute_free_baseline(rankings)
             return rankings
 
         except Exception as e:
             logger.error(f"Failed to load model rankings: {e}")
             return {}
+
+    def _compute_free_baseline(self, rankings: Dict[str, Dict]) -> None:
+        """Compute the free-model baseline: worst agentic score among free
+        providers. Models scoring below this are excluded from coding chains.
+        Runs at load + every reload (per #341 acceptance criterion 5).
+        """
+        # ponytail: FREE_PROVIDERS matches generate_virtual_models.py list.
+        free_providers = {
+            "groq", "cerebras", "gemini", "together", "g4f",
+            "nvidia", "github-models", "kilo", "modal",
+        }
+        free_scores = []
+        for key, model_data in rankings.items():
+            provider = key.split("/", 1)[0] if "/" in key else ""
+            if provider not in free_providers:
+                continue
+            scores = model_data.get("scores", {})
+            ag = scores.get("agentic_coding", scores.get("swe_bench", 0.0))
+            if ag > 0:
+                free_scores.append(ag)
+
+        if free_scores:
+            self._free_baseline = max(min(free_scores), self.FREE_BASELINE_FLOOR)
+            logger.info(f"Free-model baseline: {self._free_baseline}")
+        else:
+            self._free_baseline = self.FREE_BASELINE_FLOOR
+
+    def _below_free_baseline(self, agentic_score: float) -> bool:
+        """True if model scores below the free-model baseline."""
+        baseline = getattr(self, "_free_baseline", self.FREE_BASELINE_FLOOR)
+        return 0 < agentic_score < baseline
 
     def get_model_score(self, provider: str, model: str) -> Optional[float]:
         """Get agentic coding score for a model."""
@@ -259,7 +310,10 @@ class DynamicScoringEngine:
         hallucination_rate = self.get_hallucination_rate(provider, model)
         web_search_capable = self.get_web_search_capable(provider, model)
 
+        # ponytail: normalize to 0-100 range to match agentic_score scale.
+        # tps/20 caps at 100 (200+ TPS = max). availability already 0-1 -> *100.
         tps_normalized = min(tps / 20.0, 100.0)
+        availability_normalized = availability * 100.0
         hallucination_penalty = min(hallucination_rate / 20.0, 100.0)
 
         if web_search_capable:
@@ -274,11 +328,22 @@ class DynamicScoringEngine:
             total_score += agentic_score * weights["intelligence"]
         if "tps" in weights:
             total_score += tps_normalized * weights["tps"]
+        if "availability" in weights:
+            total_score += availability_normalized * weights["availability"]
         if "hallucination_penalty" in weights:
             total_score -= hallucination_penalty * weights["hallucination_penalty"]
 
         threshold = self.THRESHOLDS.get(virtual_model_type, 0.0)
         meets_threshold = agentic_score >= threshold
+
+        # ponytail: free-baseline exclusion (#341) — coding-* only. Chat
+        # chains use intelligence, not agentic_coding, so the coding baseline
+        # would wrongly penalize good chat models with low SWE-bench scores.
+        if virtual_model_type.startswith("coding") and self._below_free_baseline(
+            agentic_score
+        ):
+            total_score = 0.0
+            meets_threshold = False
 
         return ModelScore(
             provider=provider,
@@ -302,7 +367,8 @@ class DynamicScoringEngine:
             candidates: List of (provider, model) tuples
 
         Returns:
-            List of ModelScore objects sorted by total_score descending
+            List of ModelScore objects sorted by total_score descending.
+            Below-threshold models demoted to tail (last-resort) per #341.
         """
         scores = []
 
@@ -310,8 +376,13 @@ class DynamicScoringEngine:
             score = self.calculate_coding_score(provider, model, virtual_model_type)
             scores.append(score)
 
-        # Sort by total_score descending
-        scores.sort(key=lambda s: s.total_score, reverse=True)
+        # ponytail: #341 threshold enforcement. Sort by (meets_threshold,
+        # total_score) so below-threshold models sink to tail regardless of
+        # their raw score. Free-baseline-excluded (score=0) sort last too.
+        scores.sort(
+            key=lambda s: (s.meets_threshold, s.total_score),
+            reverse=True,
+        )
 
         return scores
 

--- a/tests/test_scoring_engine_341.py
+++ b/tests/test_scoring_engine_341.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Tests for DynamicScoringEngine #341 changes: 80/15/5 weights,
+SWE-bench threshold enforcement, and free-model baseline exclusion.
+
+Loads scoring_engine.py via importlib to avoid package-install deps,
+matching the test_rank_models.py pattern in this repo.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_SRC_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "rotator_library"
+    / "scoring_engine.py"
+)
+spec = importlib.util.spec_from_file_location("scoring_engine", _SRC_PATH)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["scoring_engine"] = mod
+spec.loader.exec_module(mod)
+
+DynamicScoringEngine = mod.DynamicScoringEngine
+ModelScore = mod.ModelScore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_rankings(tmp_path: Path, models: list[dict]) -> Path:
+    """Write a minimal model_rankings.yaml for testing."""
+    import yaml
+
+    path = tmp_path / "model_rankings.yaml"
+    data = {"models": models}
+    path.write_text(yaml.dump(data))
+    return path
+
+
+@pytest.fixture
+def engine_no_telemetry(tmp_path):
+    """Engine with no telemetry (uses fallback TPS=100, availability=1.0)."""
+    models = [
+        {"id": "nvidia/claude-opus-4-5", "scores": {"agentic_coding": 74.4}},
+        {"id": "nvidia/gemini-3-pro", "scores": {"agentic_coding": 74.2}},
+        {"id": "groq/llama-3.3-70b", "scores": {"agentic_coding": 65.2}},
+        {"id": "groq/weak-model", "scores": {"agentic_coding": 20.0}},
+    ]
+    path = _write_rankings(tmp_path, models)
+    eng = DynamicScoringEngine(telemetry_manager=None, model_rankings_path=str(path))
+    eng.load_model_rankings()
+    return eng
+
+
+# ---------------------------------------------------------------------------
+# Weight change: 80/15/5
+# ---------------------------------------------------------------------------
+
+
+class TestWeights80155:
+    def test_coding_elite_weights_sum_and_split(self):
+        w = DynamicScoringEngine.CATEGORY_WEIGHTS["coding-elite"]
+        assert w["agentic"] == 0.80
+        assert w["tps"] == 0.15
+        assert w["availability"] == 0.05
+
+    def test_coding_smart_weights(self):
+        w = DynamicScoringEngine.CATEGORY_WEIGHTS["coding-smart"]
+        assert w["agentic"] == 0.80
+        assert w["tps"] == 0.15
+        assert w["availability"] == 0.05
+
+    def test_chat_elite_has_availability(self):
+        w = DynamicScoringEngine.CATEGORY_WEIGHTS["chat-elite"]
+        assert w["availability"] == 0.05
+        assert w["intelligence"] == 0.80
+
+    def test_no_legacy_75_15_10(self):
+        """Ensure old 75/15/10 weights are gone."""
+        w = DynamicScoringEngine.CATEGORY_WEIGHTS["coding-elite"]
+        assert w["agentic"] != 0.75
+
+    def test_availability_contributes_to_score(self, engine_no_telemetry):
+        """Availability (default 1.0 with no telemetry) adds 5% of 100 = 5."""
+        score = engine_no_telemetry.calculate_coding_score(
+            "nvidia", "claude-opus-4-5", "coding-elite"
+        )
+        # agentic 74.4 * 0.80 = 59.52
+        # tps fallback 100 -> 100/20=5.0 *0.15 = 0.75
+        # availability 1.0*100=100 * 0.05 = 5.0
+        # hallucination default 10.0 -> 10/20=0.5 *0.10 = -0.05
+        assert score.total_score == pytest.approx(59.52 + 0.75 + 5.0 - 0.05, abs=0.5)
+
+
+# ---------------------------------------------------------------------------
+# Threshold enforcement (coding-elite 70, coding-smart 65)
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdEnforcement:
+    def test_elite_threshold_is_70(self):
+        assert DynamicScoringEngine.THRESHOLDS["coding-elite"] == 70.0
+
+    def test_smart_threshold_is_65(self):
+        assert DynamicScoringEngine.THRESHOLDS["coding-smart"] == 65.0
+
+    def test_below_elite_threshold_meets_false(self, engine_no_telemetry):
+        """llama-3.3-70b (65.2) < 70 elite threshold -> meets_threshold False."""
+        score = engine_no_telemetry.calculate_coding_score(
+            "groq", "llama-3.3-70b", "coding-elite"
+        )
+        assert score.agentic_score == pytest.approx(65.2)
+        assert score.meets_threshold is False
+
+    def test_above_elite_threshold_meets_true(self, engine_no_telemetry):
+        """claude-opus-4-5 (74.4) >= 70 -> meets_threshold True."""
+        score = engine_no_telemetry.calculate_coding_score(
+            "nvidia", "claude-opus-4-5", "coding-elite"
+        )
+        assert score.meets_threshold is True
+
+    def test_smart_threshold_65_passes_llama(self, engine_no_telemetry):
+        """llama-3.3-70b (65.2) >= 65 smart threshold -> meets True."""
+        score = engine_no_telemetry.calculate_coding_score(
+            "groq", "llama-3.3-70b", "coding-smart"
+        )
+        assert score.meets_threshold is True
+
+    def test_below_threshold_demoted_to_tail_in_rank(self, engine_no_telemetry):
+        """When ranking, below-threshold models sort after above-threshold."""
+        candidates = [
+            ("groq", "llama-3.3-70b"),  # 65.2 < 70 elite
+            ("nvidia", "claude-opus-4-5"),  # 74.4 >= 70
+        ]
+        ranked = engine_no_telemetry.rank_models_for_virtual("coding-elite", candidates)
+        # opus first (meets threshold), llama second (demoted)
+        assert ranked[0].model == "claude-opus-4-5"
+        assert ranked[1].model == "llama-3.3-70b"
+        assert ranked[0].meets_threshold is True
+        assert ranked[1].meets_threshold is False
+
+    def test_chat_unaffected_by_swe_threshold(self, engine_no_telemetry):
+        """chat-elite has threshold 0.0, so weak model still meets_threshold."""
+        score = engine_no_telemetry.calculate_coding_score(
+            "groq", "weak-model", "chat-elite"
+        )
+        assert score.meets_threshold is True  # threshold 0.0
+
+
+# ---------------------------------------------------------------------------
+# Free-model baseline exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestFreeBaselineExclusion:
+    def test_baseline_computed_at_load(self, tmp_path):
+        """Free baseline = worst free-model agentic score, >= hard floor 30."""
+        models = [
+            {"id": "nvidia/strong-free", "scores": {"agentic_coding": 74.0}},
+            {"id": "groq/weak-free", "scores": {"agentic_coding": 45.0}},
+            {"id": "openai/paid-model", "scores": {"agentic_coding": 90.0}},
+        ]
+        path = _write_rankings(tmp_path, models)
+        eng = DynamicScoringEngine(
+            telemetry_manager=None, model_rankings_path=str(path)
+        )
+        eng.load_model_rankings()
+        # free scores: nvidia 74, groq 45 -> min=45 -> baseline=max(45,30)=45
+        assert eng._free_baseline == 45.0
+
+    def test_below_baseline_score_zeroed(self, tmp_path):
+        """Model below free baseline gets total_score=0 + meets_threshold False."""
+        models = [
+            {"id": "nvidia/good-free", "scores": {"agentic_coding": 60.0}},
+            {"id": "openai/terrible-paid", "scores": {"agentic_coding": 10.0}},
+        ]
+        path = _write_rankings(tmp_path, models)
+        eng = DynamicScoringEngine(
+            telemetry_manager=None, model_rankings_path=str(path)
+        )
+        eng.load_model_rankings()
+        # baseline = max(min([60]), 30) = 60. terrible-paid 10 < 60 -> zeroed.
+        score = eng.calculate_coding_score(
+            "openai", "terrible-paid", "coding-elite"
+        )
+        assert score.total_score == 0.0
+        assert score.meets_threshold is False
+
+    def test_baseline_floor_enforced(self, tmp_path):
+        """If all free models score low, baseline floors at 30."""
+        models = [
+            {"id": "groq/weak-1", "scores": {"agentic_coding": 5.0}},
+            {"id": "groq/weak-2", "scores": {"agentic_coding": 10.0}},
+        ]
+        path = _write_rankings(tmp_path, models)
+        eng = DynamicScoringEngine(
+            telemetry_manager=None, model_rankings_path=str(path)
+        )
+        eng.load_model_rankings()
+        assert eng._free_baseline == 30.0  # floor
+
+    def test_baseline_recomputed_on_reload(self, tmp_path):
+        """Reloading rankings after file change recomputes baseline (#341 AC5)."""
+        import yaml
+
+        path = tmp_path / "model_rankings.yaml"
+        path.write_text(
+            yaml.dump(
+                {"models": [{"id": "nvidia/m", "scores": {"agentic_coding": 40.0}}]}
+            )
+        )
+        eng = DynamicScoringEngine(
+            telemetry_manager=None, model_rankings_path=str(path)
+        )
+        eng.load_model_rankings()
+        assert eng._free_baseline == 40.0
+
+        # Overwrite with higher scores
+        path.write_text(
+            yaml.dump(
+                {"models": [{"id": "nvidia/m", "scores": {"agentic_coding": 80.0}}]}
+            )
+        )
+        eng.load_model_rankings()
+        assert eng._free_baseline == 80.0
+
+
+# ---------------------------------------------------------------------------
+# Self-check
+# ---------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Updates runtime scoring to 80/15/5 (agentic/TPS/availability) per #341.

## Changes
- `src/rotator_library/scoring_engine.py`: CATEGORY_WEIGHTS 80/15/5, SWE thresholds (elite >=70, smart >=65), free-baseline exclusion (floor 30, coding-* only), sort by meets_threshold first
- `DESIGN.md`: 60/30/10 -> 80/15/5 + threshold section
- `tests/test_scoring_engine_341.py`: 16 new tests (weights/threshold/free-baseline)
- `config/scoring_config.yaml` + `scripts/generate_virtual_models.py`: pre-existing 80/15/5 edits from other machine

## Verification
- `pytest tests/test_scoring_engine_341.py` -> 16 passed
- `pytest tests/test_scoring_engine_341.py tests/test_rank_models.py tests/test_build_embedding_chain.py` -> 61 passed
- `python scripts/reorder_chains.py --use-u-formula` -> ran clean (0 reordered, no local telemetry DB as expected)
- Other test files require litellm (VPS-only env) — pre-existing, not regression

Closes #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated model scoring to weigh agentic quality more heavily, with availability now contributing to rankings.
  * Added free-model baseline handling so lower-scoring coding models are deprioritized.

* **Bug Fixes**
  * Improved ranking behavior so models below thresholds are pushed to the end of results.
  * Adjusted coding and chat scoring thresholds and penalties for more consistent ordering.

* **Tests**
  * Added coverage for the new scoring weights, threshold behavior, and baseline-based exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->