### PR TITLE
fix(gateway): strip cache_control for non-Anthropic downstreams (#346)

### DIFF
--- a/src/proxy_app/router_core.py
+++ b/src/proxy_app/router_core.py
@@ -30,6 +30,24 @@ logger = logging.getLogger(__name__)
 from .litellm_fallback import build_litellm_fallback_kwargs  # noqa: E402
 
 
+def _strip_cache_control(obj: Any) -> Any:
+    """Recursively delete Anthropic `cache_control` keys from request payloads.
+
+    opencode's Anthropic adapter stamps `cache_control:{type:ephemeral}` onto
+    message blocks and tool_calls. OpenAI-compatible / Pydantic-strict downstreams
+    reject this unknown nested field. Call this before dispatch to any
+    non-Anthropic-native downstream (#346).
+    """
+    if isinstance(obj, dict):
+        obj.pop("cache_control", None)
+        for v in list(obj.values()):
+            _strip_cache_control(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            _strip_cache_control(item)
+    return obj
+
+
 class ProviderStatus(Enum):
     """Provider health status."""
 
@@ -831,6 +849,7 @@ class RouterCore:
                 )
                 request_clean["max_tokens"] = 1024
             request_clean["model"] = f"{candidate.provider}/{candidate.model}"
+            _strip_cache_control(request_clean)
 
             logger.info(
                 f"[{request_id}] Executing via {candidate.provider}/{candidate.model}"
@@ -1761,6 +1780,7 @@ class RouterCore:
                     f"[{request_id}] Capping max_tokens {requested_max_tokens} -> 1024 for provider fallback"
                 )
                 request_clean["max_tokens"] = 1024
+            _strip_cache_control(request_clean)
 
             logger.info(
                 f"[{request_id}] Streaming {candidate.provider}/{candidate.model}"

--- a/tests/test_strip_cache_control.py
+++ b/tests/test_strip_cache_control.py
@@ -1,0 +1,109 @@
+"""Tests for _strip_cache_control (#346).
+
+Extracts the ACTUAL function source from router_core.py via AST and tests it
+in isolation, avoiding the module's heavy import chain (litellm/fastapi/etc
+not installed locally — they live on the VPS).
+"""
+
+import ast
+import pathlib
+import textwrap
+
+
+def _extract_function():
+    """Pull _strip_cache_control source from router_core.py, exec in clean ns."""
+    src = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "src"
+        / "proxy_app"
+        / "router_core.py"
+    ).read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_strip_cache_control":
+            fn_src = ast.get_source_segment(src, node)
+            ns = {"Any": object}
+            exec(textwrap.dedent(fn_src), ns)
+            return ns["_strip_cache_control"]
+    raise RuntimeError("_strip_cache_control not found in router_core.py")
+
+
+strip = _extract_function()
+
+
+class TestStripCacheControl:
+    def test_strips_from_message_content_blocks(self):
+        payload = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}},
+                        {"type": "text", "text": "there"},
+                    ],
+                }
+            ]
+        }
+        out = strip(payload)
+        assert "cache_control" not in out["messages"][0]["content"][0]
+        assert out["messages"][0]["content"][0]["text"] == "hi"
+
+    def test_strips_from_tool_calls(self):
+        payload = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "foo", "arguments": "{}"},
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                }
+            ]
+        }
+        out = strip(payload)
+        assert "cache_control" not in out["messages"][0]["tool_calls"][0]
+        assert out["messages"][0]["tool_calls"][0]["function"]["name"] == "foo"
+
+    def test_preserves_other_fields(self):
+        payload = {"model": "x", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 10}
+        out = strip(payload)
+        assert out == payload
+
+    def test_empty_and_scalars_passthrough(self):
+        assert strip({}) == {}
+        assert strip([]) == []
+        assert strip("str") == "str"
+        assert strip(42) == 42
+
+    def test_nested_lists_and_dicts(self):
+        payload = {
+            "messages": [
+                {
+                    "content": [
+                        {"cache_control": {"type": "ephemeral"}, "nested": [{"cache_control": "x", "v": 1}]}
+                    ],
+                }
+            ]
+        }
+        out = strip(payload)
+        block = out["messages"][0]["content"][0]
+        assert "cache_control" not in block
+        assert "cache_control" not in block["nested"][0]
+        assert block["nested"][0]["v"] == 1
+
+    def test_in_place_mutation_documented(self):
+        """Function mutates in place (perf) AND returns the obj — callers can use either."""
+        payload = {"messages": [{"content": [{"cache_control": {"type": "ephemeral"}, "text": "hi"}]}]}
+        ret = strip(payload)
+        assert ret is payload
+        assert "cache_control" not in payload["messages"][0]["content"][0]
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-q"])


### PR DESCRIPTION
## Summary

Fixes #346. Recursive `_strip_cache_control(obj)` helper in `router_core.py` that deletes Anthropic `cache_control` keys from message blocks, content blocks, and tool_calls before dispatch to downstream providers.

## Root cause

opencode's @ai-sdk/anthropic adapter stamps `cache_control:{type:ephemeral}` onto message text blocks and tool_calls. This is legal on Anthropic's native API but rejected by OpenAI-compatible / Pydantic-strict downstreams with:

```
Extra inputs are not permitted, field: messages[N].tool_calls[M].cache_control
```

`litellm.drop_params=True` only drops top-level params, not nested fields inside messages/tool_calls. The antigravity provider adapter has its own `_strip_cache_control` for Gemini conversion, but no gateway-wide strip existed.

## Changes

- `src/proxy_app/router_core.py`: added `_strip_cache_control(obj)` module-level helper (recursive dict/list traversal, pops `cache_control` keys in place). Called in:
  - `_execute_single_candidate` (non-stream path, L834) after `request_clean` is built
  - `_execute_single_candidate_stream` (stream path, L1765) after `request_clean` is built
- `tests/test_strip_cache_control.py`: 6 tests (AST-extracts the real function source from router_core.py to avoid the heavy litellm/fastapi import chain; runs in isolation).

## Relationship to opencode-side fix

Complements the opencode-side fix applied 2026-07-04 (split sh00t provider in opencode.stock.json into sh00t + sh00t-anthropic with @ai-sdk/anthropic for Claude models). The opencode-side fix sends native /v1/messages where cache_control IS valid. This gateway-side fix handles the case where requests still carry cache_control to OpenAI-compatible downstreams — works for ALL gatewayed instances automatically, not just the one-machine opencode config.

## Verification

```
python3 -m pytest tests/test_strip_cache_control.py tests/test_scoring_engine_341.py tests/test_rank_models.py tests/test_build_embedding_chain.py -q
# 67 passed
```

No regressions in existing tests. New function is pure recursion (no I/O, no side effects beyond in-place mutation which is documented behavior).