### PR TITLE
docs: refresh stale AGENTS.md with accurate file sizes, providers, restart cmd (#356)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,50 @@
 # LLM-API-Key-Proxy Knowledge Base
 
-**Generated:** 2026-02-05
-**Commit:** 0342491
-**Branch:** (check with `git branch`)
+**Last refreshed:** 2026-07-11
+**Commit:** 12e0ccb
+**Branch:** main
 
 ## OVERVIEW
 
-FastAPI-based LLM API proxy with virtual models and automatic fallback. Routes requests through 10+ free LLM providers (Groq, Gemini, G4F, etc.) with intelligent fallback chains.
+FastAPI-based LLM API proxy with virtual models and automatic fallback. Routes requests through 33 free LLM providers (groq, gemini, cerebras, nvidia, mistral, openrouter, sambanova, together, cloudflare, bluesminds, kilo, freemodel, freemodel-anthropic, supacoder, wiwi, iflow, xinjianya, g4f_*, github-models, aihubmix, antigravity, brave_search, duckduckgo, exa, jina, tavily, cloudflare, zyf, etc.) with telemetry-driven fallback chains.
 
 ## STRUCTURE
 
 ```
 LLM-API-Key-Proxy/
-├── config/              # YAML configs (router, virtual models, aliases)
+├── config/              # YAML configs (router, virtual models, aliases, scoring)
+│   ├── router_config.yaml       # Provider enable/disable + keys (33 providers)
+│   ├── virtual_models.yaml      # 17 virtual model fallback chains
+│   ├── model_rankings.yaml       # Telemetry-derived model scores (~101K)
+│   ├── providers_database.yaml   # Provider catalog (~64K)
+│   ├── cooldown_policy.yaml      # Wait-vs-fallback per provider
+│   ├── concurrency_policy.yaml    # Per-(provider,model) slot limits
+│   ├── scoring_config.yaml       # U-formula weights
+│   └── tier_config.yaml          # Model tier definitions
 ├── src/
-│   ├── proxy_app/       # Main gateway (entry: main.py, 1357 lines)
-│   │   ├── main.py           # FastAPI app, /v1/chat/completions endpoint
-│   │   ├── router_core.py    # Router logic (1683 lines)
-│   │   ├── settings_tool.py  # Settings management (2450 lines)
-│   │   ├── launcher_tui.py   # Terminal UI launcher (1003 lines)
-│   │   └── provider_urls.py  # Provider URL construction
-│   └── rotator_library/  # Core library (49k lines total)
-│       ├── client.py           # RotatingClient (2674 lines)
-│       ├── credential_tool.py  # OAuth credential management (2255 lines)
-│       ├── usage_manager.py    # Usage tracking (1792 lines)
-│       ├── model_info_service.py # Model metadata (1352 lines)
-│       ├── error_handler.py    # Error handling (976 lines)
-│       └── providers/          # Provider adapters (antigravity, gemini_cli, etc.)
+│   ├── proxy_app/       # Main gateway (~16K lines)
+│   │   ├── main.py              # FastAPI app, /v1/chat/completions (1698 lines)
+│   │   ├── router_core.py       # Router + fallback logic (2514 lines)
+│   │   ├── settings_tool.py     # Settings management (2450 lines)
+│   │   ├── launcher_tui.py       # Terminal UI launcher (1003 lines)
+│   │   └── provider_urls.py      # Provider URL construction (100 lines)
+│   └── rotator_library/  # Core library (~34K lines, 33 provider adapters)
+│       ├── client.py              # RotatingClient (3227 lines)
+│       ├── credential_tool.py     # OAuth credential management (2273 lines)
+│       ├── usage_manager.py        # Usage tracking (1812 lines)
+│       ├── model_info_service.py   # Model metadata (1352 lines)
+│       ├── telemetry.py            # LiteLLM telemetry logger (1257 lines)
+│       ├── provider_status_tracker.py # SQLite health probes (984 lines)
+│       ├── error_handler.py        # Error handling (974 lines)
+│       ├── dynamic_chain.py        # Telemetry-driven re-ranker (387 lines)
+│       ├── scoring_engine.py       # U-formula scoring (392 lines)
+│       ├── distributed_gate.py      # Cross-process cooldown (382 lines)
+│       ├── cost_efficiency.py       # Cost archetype routing (300 lines)
+│       └── providers/               # 33 provider adapters (antigravity, gemini_cli, g4f, etc.)
 ├── scripts/             # Utility scripts
 ├── tests/               # Test fixtures
 ├── docs/                # Documentation
+├── SPEC.md              # Project spec (379 lines)
 └── .env                 # API keys (NOT committed)
 ```
 
@@ -37,66 +52,86 @@ LLM-API-Key-Proxy/
 
 | Task | Location | Notes |
 |------|----------|-------|
-| Add `/v1/responses` endpoint | `src/proxy_app/main.py:882` | Add new route for OpenCode Responses API |
-| Virtual models | `config/virtual_models.yaml` | coding-elite, coding-fast, etc. |
-| Provider routing | `src/proxy_app/router_core.py` | Fallback logic |
-| Provider adapters | `src/rotator_library/providers/` | Individual provider implementations |
-| Router configuration | `config/router_config.yaml` | Provider enable/disable |
+| Virtual models | `config/virtual_models.yaml` | 17 chains: coding-elite, coding-fast, chat-elite, auto, etc. |
+| Provider routing | `src/proxy_app/router_core.py` (2514L) | Fallback logic, retry, force-try |
+| Provider adapters | `src/rotator_library/providers/` | 33 adapter files |
+| Router configuration | `config/router_config.yaml` | Provider enable/disable (33 providers) |
+| Telemetry-driven re-rank | `src/rotator_library/dynamic_chain.py` | Uptime EMA + fail penalty + quality + cost + spread |
+| Health probes | `src/rotator_library/provider_status_tracker.py` | SQLite-persisted provider health |
+| Cooldown policy | `config/cooldown_policy.yaml` | Wait-vs-fallback (e.g. anthropic waits 300s on 429 for cache) |
+| Concurrency gating | `config/concurrency_policy.yaml` + `distributed_gate.py` | Per-(provider,model) slots |
+| Scoring config | `config/scoring_config.yaml` | U-formula weights |
 | API key auth | `src/proxy_app/` | Search for `verify_api_key` |
 | TUI launcher | `src/proxy_app/launcher_tui.py` | Interactive launcher |
 
 ## KEY CONCEPTS
 
-### Virtual Models
+### Virtual Models (17 total, chains are telemetry-reordered via `reorder_chains.py`)
 
-Pre-configured model aliases with automatic fallback chains:
-- **coding-elite**: Groq llama-3.3-70b → Gemini 1.5-pro → G4F gpt-4
-- **coding-fast**: Groq llama-3.1-8b-instant → Gemini 1.5-flash → G4F
-- **chat-smart**: Groq llama-3.3-70b → Gemini 1.5-pro
-- **chat-fast**: Groq llama-3.1-8b-instant → Gemini 1.5-flash → G4F
+Current chains (refreshed periodically by VPS cron):
+- **coding-elite**: glm-5.2 -> gpt-5.5-mini -> qwen3.7-plus -> gemini-3.5-flash
+- **coding-fast**: kimi-k2.6 -> poolside/laguna-xs.2:free -> nemotron-3-nano -> deepseek-v4-pro
+- **chat-elite**: gemini-3.1-pro-preview -> gemini-3-pro-preview -> gemini-3-pro-high -> gemini-3-pro
+- **chat-fast**: gemini-2.5-flash -> llama-3.3-70b -> llama3.1-8b -> llama-3.1-8b-instant
+- **chat-smart**: gemini-3-flash -> kimi-k2 -> gemini-2.5-flash
+- **chat-rp**: mistral-small-4-119b -> solar-10.7b -> mistral-7b -> mistral-nemotron
+- **auto**: gemini-2.5-flash -> llama-3.3-70b -> llama-3.1-8b
+- **glm5-elite**: glm-5.2 -> glm-5.1 -> glm-5
+- **agent-***: bge-m3 -> kimi-k2 -> kimi-k2.6 -> minimax-m3 (6 agent variants: build/explore/librarian/metis/momus/oracle)
+
+### Dynamic Chain Ranking (`dynamic_chain.py`)
+
+Telemetry-driven re-ranker (#251, wired via `USE_DYNAMIC_CHAIN=1` env, default off):
+- **uptime_ema**: success ratio, 30min halflife (weight 0.40)
+- **quality**: benchmark score (weight 0.25)
+- **fail_penalty**: linear decay 60s->0 (weight 0.15), full at <60s, zero at >=300s
+- **cost_eff**: archetype (weight 0.10)
+- **spread_bonus**: load distribution (weight 0.10)
+- Reads `llm_events` table from `/dev/shm/telemetry.db` (tmpfs, wiped on reboot)
+- **#354 fallback**: set `TELEMETRY_DB_FALLBACK` env to on-disk snapshot path so signals survive reboot
 
 ### Fallback Chain
 
-Router automatically tries next provider if current one fails (rate limit, error, timeout). No manual intervention.
+Router automatically tries next provider if current one fails (rate limit, error, timeout). Configurable wait-vs-switch via `cooldown_policy.yaml` (e.g. anthropic waits 300s on 429 to preserve prompt-cache discount).
 
 ### FREE_ONLY_MODE
 
 Gateway runs in free-only mode by default (`FREE_ONLY_MODE=true`). No paid API keys needed.
 
-## CONVENTIONS (Deviations from Standard)
+## CONVENTIONS
 
 ### Python
 - **Formatting:** Black, 88-char line limit
 - **Type hints:** Required for function signatures
-- **Async:** Heavy use of async/await for I/O-bound operations
+- **Async:** Heavy use of async/await + httpx
 - **Imports:** `from pathlib import Path` (not `os.path`)
-- **Logging:** Use `logging.getLogger(__name__)`
+- **Logging:** `logging.getLogger(__name__)`
 
 ### FastAPI
 - **Dependencies:** Use `Depends()` for injection (get_rotating_client, verify_api_key)
-- **Exceptions:** Raise `HTTPException(status_code=..., detail=...)`
+- **Exceptions:** `HTTPException(status_code=..., detail=...)`
 - **Request parsing:** `await request.json()` for body
 
 ### Configuration
-- **YAML files** for configs (router_config.yaml, virtual_models.yaml)
-- **Environment variables** for secrets (.env file loaded via python-dotenv)
-- **Virtual models** in `config/virtual_models.yaml`
+- **YAML** for configs (router_config.yaml, virtual_models.yaml, scoring_config.yaml, etc.)
+- **Env vars** for secrets (.env via python-dotenv)
+- **SQLite** for telemetry (`/dev/shm/telemetry.db`) + health (`provider_status.db`)
 
-## ANTI-PATTERNS (THIS PROJECT)
+## ANTI-PATTERNS
 
-❌ **DO NOT** modify `.env` file - credentials handled via OAuth credential tool
-❌ **DO NOT** hardcode API keys - use `os.getenv()` or credential tool
-❌ **DO NOT** block on async operations - use `await`
-❌ **DO NOT** make synchronous HTTP calls - use httpx with async
-❌ **DO NOT** disable rate limit checks - respect provider limits
+- DO NOT modify `.env` - credentials handled via credential tool
+- DO NOT hardcode API keys - use `os.getenv()` or credential tool
+- DO NOT make synchronous HTTP calls - use async httpx
+- DO NOT disable rate limit checks - respect provider limits
+- DO NOT use `find`, `grep`, `cat`, `head`, `tail`, `sed`, `awk` - use dedicated tools
 
 ## COMMANDS
 
 ```bash
-# Development
+# Development (local)
 python src/proxy_app/main.py --host 0.0.0.0 --port 8000
 
-# With custom config
+# With request logging
 python src/proxy_app/main.py --host 0.0.0.0 --port 8000 --enable-request-logging
 
 # OAuth credential tool
@@ -104,106 +139,59 @@ python src/proxy_app/main.py --add-credential
 
 # Terminal UI launcher (interactive)
 python src/proxy_app/main.py
-```
 
-## CURRENT ISSUE (Priority)
-
-**OpenCode Integration Broken**
-
-OpenCode uses OpenAI **Responses API** (`POST /v1/responses`), but gateway only implements **Chat Completions API** (`POST /v1/chat/completions`).
-
-**Error:** `404 Not Found` when OpenCode calls `/v1/responses`
-
-**Solution needed:**
-1. Add `/v1/responses` endpoint to `src/proxy_app/main.py`
-2. Translate Responses API format → Chat Completions format
-3. Call existing `chat_completions()` function
-4. Translate response back to Responses API format
-5. Commit → push to GitHub → VPS pulls automatically
-
-**Test command:**
-```bash
-curl -X POST http://40.233.101.233:8000/v1/responses \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer CHANGE_ME_TO_A_STRONG_SECRET_KEY" \
-  -d '{"model": "coding-elite", "input": [{"type": "message", "role": "user", "content": [{"type": "text", "text": "Hello"}]}]}'
+# Self-tests (stdlib-only, no frameworks)
+python3 src/rotator_library/dynamic_chain.py    # -> 'dynamic_chain self-test: OK'
+python3 src/rotator_library/distributed_gate.py  # -> 'distributed_gate self-test: OK'
 ```
 
 ## TESTING
 
 ```bash
-# Test gateway is running
+# Test gateway running
 curl http://40.233.101.233:8000/v1/models \
-  -H "Authorization: Bearer CHANGE_ME_TO_A_STRONG_SECRET_KEY"
+  -H "Authorization: Bearer $VPS_GATEWAY_API_KEY"
 
 # Test virtual model
 curl -X POST http://40.233.101.233:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer CHANGE_ME_TO_A_STRONG_SECRET_KEY" \
+  -H "Authorization: Bearer $VPS_GATEWAY_API_KEY" \
   -d '{"model": "coding-elite", "messages": [{"role": "user", "content": "Hello"}], "max_tokens": 10}'
 ```
 
 ## GIT WORKFLOW
 
 **Remote:** https://github.com/ons96/LLM-API-Key-Proxy
-**VPS pulls:** Changes auto-pull on VPS (verify with SSH)
+**VPS auto-pull:** VPS-40 pulls on push (verify with SSH)
 
 ```bash
-# On VPS
+# On VPS-40
 ssh -i ~/.ssh/oracle.key ubuntu@40.233.101.233
 cd ~/LLM-API-Key-Proxy
 git pull
 
-# Restart gateway
-pkill -f 'main.py'
-source venv/bin/activate
-nohup python src/proxy_app/main.py --host 0.0.0.0 --port 8000 > ~/llm_proxy.log 2>&1 &
+# Restart gateway (systemd-managed on VPS-40)
+sudo systemctl restart llm-gateway
+# (NOT pkill -f main.py; gateway is under systemd with MemoryMax=400M)
 ```
 
-## OPENCODE CONFIGURATION
+## ENV VARS
 
-**File:** `/home/owens/.config/opencode/opencode.json`
+### Gateway control
+- `GATEWAY_RETRY_UNTIL_DONE` (default false): retry whole chain on hard failure with backoff 2/4/8s, max 3
+- `GATEWAY_FORCE_TRY_COOLDOWN` (default false): ignore cooldown state, try all candidates
+- `FREE_ONLY_MODE` (default true): reject non-free providers
+- `USE_DYNAMIC_CHAIN` (default false): enable telemetry-driven re-ranking (#251)
 
-Configured to use VPS gateway:
-```json
-{
-  "model": "openai/coding-elite",
-  "provider": {
-    "openai": {
-      "name": "My VPS LLM Gateway",
-      "options": {
-        "baseURL": "http://40.233.101.233:8000/v1",
-        "apiKey": "CHANGE_ME_TO_A_STRONG_SECRET_KEY"
-      }
-    }
-  }
-}
-```
+### Telemetry
+- `TELEMETRY_DB_PATH` (default `/dev/shm/telemetry.db`): tmpfs telemetry store
+- `TELEMETRY_DB_FALLBACK` (default empty): on-disk snapshot fallback so signals survive reboot (#354)
 
 ## GOTCHAS
 
-⚠️ **VPS uses different port than local:** Local testing uses 8000, ensure correct
-⚠️ **API key in header:** Use `Authorization: Bearer <key>` (not `X-API-Key`)
-⚠️ **Free-only mode:** Gateway rejects non-free providers unless configured
-⚠️ **G4F models:** Some complex IDs don't work (stick to simple names like `g4f/gpt-4`)
-
-
-## NEW ENV VARS (added 2026-06-04)
-
-### GATEWAY_RETRY_UNTIL_DONE
-- Default: `false`
-- When `true`: if all candidates in fallback chain fail, retry the whole chain with exponential backoff (2s, 4s, 8s). Max 3 retries (~14s total).
-- Use case: autonomous workflows that must never silently give up on a request.
-- Trade-off: can mask provider outages for ~14s. Disable for latency-sensitive use.
-
-### GATEWAY_FORCE_TRY_COOLDOWN
-- Default: `false`
-- When `true`: ignore provider cooldown state, try all candidates regardless of recent failures.
-- Use case: when gateway should never stop rotating, even on recently-failed providers.
-- Combine with GATEWAY_RETRY_UNTIL_DONE for full "never stop" mode.
-
-## FIXES APPLIED 2026-06-04
-
-- Removed 5s sleep before final error in router_core.py (both stream and non-stream paths). Was wasting 5s on hard failures.
-- Weakened cooldown filter: now configurable via GATEWAY_FORCE_TRY_COOLDOWN.
-- Wrapped route_request with _route_with_retry for GATEWAY_RETRY_UNTIL_DONE.
+- **VPS restart:** Gateway is systemd-managed (`sudo systemctl restart llm-gateway`), NOT nohup+pkill. MemoryMax=400M on VPS-40.
+- **Telemetry tmpfs:** `/dev/shm/telemetry.db` is wiped on machine reboot. Set `TELEMETRY_DB_FALLBACK` to survive (#354).
+- **G4F models:** Some complex IDs don't work (stick to simple names like `g4f/gpt-4`)
+- **Virtual chains are dynamic:** `reorder_chains.py` rewrites `virtual_models.yaml` from telemetry every 30min on VPS-40. Don't hand-edit chains expecting persistence.
+- **Dynamic chain is opt-in:** `USE_DYNAMIC_CHAIN=1` must be set or the static chain from `virtual_models.yaml` is used as-is.
+- **Cooldown policy is per-provider:** `cooldown_policy.yaml` decides wait-vs-switch (e.g. anthropic/openai wait on 429 for cache; default switches immediately).


### PR DESCRIPTION
## What
Refreshed `AGENTS.md` which hadn't been updated since 2026-02-05 (commit 0342491). Per issue #356.

## Changes
- Provider count: 10+ -> 33 (actual in router_config.yaml)
- File line counts: main.py 1357->1698, router_core.py 1683->2514, client.py 2674->3227, rotator_library ~34K total
- Virtual model chains: 5-month-old examples -> current 17 telemetry-reordered chains (coding-elite, coding-fast, chat-rp, agent-*, etc.)
- Restart command: `pkill+nohup` -> `systemctl restart llm-gateway` (systemd-managed on VPS-40, MemoryMax=400M)
- Added dynamic_chain ranking docs (uptime_ema/fail_penalty/quality/cost/spread weights, USE_DYNAMIC_CHAIN env)
- Added TELEMETRY_DB_FALLBACK env (#354 reboot survival)
- Added configs: cooldown_policy.yaml, concurrency_policy.yaml, scoring_config.yaml, tier_config.yaml
- Added self-test commands (dynamic_chain, distributed_gate)
- Added gotchas: tmpfs wipe on reboot, reorder_chains.py dynamic rewrite, dynamic chain opt-in, cooldown policy per-provider
- Removed stale 'CURRENT ISSUE: OpenCode Integration Broken' section (resolved)
- Removed hardcoded API key placeholder in opencode config example

## Verification
- No code changes (doc-only), no tests needed
- All file sizes verified via `wc -l`
- Provider count verified via `python3 -c "import yaml; ..."` on router_config.yaml
- Closes #356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to reflect the current provider routing, fallback chains, telemetry, and cooldown behavior.
  * Refreshed project structure references, testing commands, environment variable guidance, and operational workflows.
  * Updated service management instructions to use system service controls.
  * Removed outdated integration, configuration, and historical issue guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->