### PR TITLE
fix(chains): gate dead fallback candidates

### DIFF
--- a/config/dead_providers.yaml
+++ b/config/dead_providers.yaml
@@ -1,0 +1,52 @@
+version: 1
+
+# This filters fallback-chain membership only. Provider/model catalogs and
+# benchmark history remain intact so a provider can be restored after a recheck.
+blocked_providers:
+  - provider: kilo
+    reason: Kilo API endpoint returned a Vercel 404 page
+    last_confirmed_dead: "2026-07-16"
+  - provider: antigravity
+    reason: OAuth route is unavailable
+    last_confirmed_dead: "2026-07-16"
+
+blocked_provider_prefixes:
+  - prefix: g4f_
+    reason: g4f provider variants are unreliable fallbacks
+    last_confirmed_dead: "2026-07-16"
+
+blocked_models:
+  - provider: cliproxyapi
+    model_prefix: gemini-3
+    allow_models:
+      - gemini-3-flash
+    reason: Gemini 3 variants are unsupported by CLIProxyAPI
+    last_confirmed_dead: "2026-07-16"
+  - provider: cerebras
+    model: qwen-3-235b-a22b-instruct-2507
+    reason: Model returned NotFound
+    last_confirmed_dead: "2026-07-16"
+  - provider: supacoder
+    model: gpt-5.4
+    reason: Provider blocks requests for this model
+    last_confirmed_dead: "2026-07-16"
+  - provider: gemini
+    model: gemini-3-pro
+    reason: Model is unavailable
+    last_confirmed_dead: "2026-07-16"
+  - provider: gemini
+    model: gemini-3.1-pro
+    reason: Model is unavailable
+    last_confirmed_dead: "2026-07-16"
+
+# At least one of these direct providers must remain in every generated or
+# rebuilt chain so free aggregator failures cannot exhaust the chain.
+direct_free_fallbacks:
+  - provider: groq
+    model: llama-3.3-70b-versatile
+  - provider: cerebras
+    model: llama-3.3-70b
+  - provider: gemini
+    model: gemini-2.5-flash
+  - provider: cliproxyapi
+    model: gemini-2.5-flash

--- a/scripts/chain_policy.py
+++ b/scripts/chain_policy.py
@@ -6,6 +6,8 @@ benchmark data, or other historical records.
 
 from __future__ import annotations
 
+import os
+import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -135,6 +137,37 @@ def validate_chain(entries: Iterable[Mapping[str, Any]], policy: Mapping[str, An
         reason = blocked_reason(provider, model, policy)
         if reason:
             raise ValueError(f"blocklisted fallback entry {provider}/{model}: {reason}")
+
+
+def write_yaml_atomic(path: Path, document: Any, *, allow_unicode: bool = False) -> None:
+    """Replace a YAML file without exposing a partially written config."""
+    mode = path.stat().st_mode & 0o777 if path.exists() else 0o644
+    rendered = yaml.safe_dump(
+        document,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=allow_unicode,
+    )
+    temporary: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary = Path(handle.name)
+        temporary.chmod(mode)
+        temporary.replace(path)
+    except Exception:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        raise
 
 
 def sanitize_chain(

--- a/scripts/chain_policy.py
+++ b/scripts/chain_policy.py
@@ -1,0 +1,178 @@
+"""Non-destructive fallback-chain policy shared by chain writers.
+
+This module only filters chain entries. It never edits provider catalogs,
+benchmark data, or other historical records.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import yaml
+
+
+DEFAULT_POLICY_PATH = Path(__file__).resolve().parent.parent / "config" / "dead_providers.yaml"
+
+
+def _normalized(value: Any) -> str:
+    return str(value).strip().lower()
+
+
+def _model_component(model: Any) -> str:
+    return _normalized(model).rsplit("/", 1)[-1]
+
+
+def candidate_key(provider: Any, model: Any) -> Tuple[str, str]:
+    """Return a normalized provider/model identity for chain comparison."""
+    return _normalized(provider), _normalized(model)
+
+
+def _entry_values(entry: Mapping[str, Any]) -> Tuple[str, str]:
+    provider = entry.get("provider")
+    model = entry.get("model")
+    if not isinstance(provider, str) or not provider.strip():
+        raise ValueError("fallback entry requires a non-empty string provider")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError("fallback entry requires a non-empty string model")
+    return provider.strip(), model.strip()
+
+
+def load_policy(path: Optional[Path | str] = None) -> Dict[str, Any]:
+    """Load and validate the reversible fallback-chain exclusion policy."""
+    policy_path = Path(path) if path is not None else DEFAULT_POLICY_PATH
+    with policy_path.open() as policy_file:
+        policy = yaml.safe_load(policy_file) or {}
+    if not isinstance(policy, dict):
+        raise ValueError(f"chain policy must be a mapping: {policy_path}")
+
+    for key in (
+        "blocked_providers",
+        "blocked_provider_prefixes",
+        "blocked_models",
+        "direct_free_fallbacks",
+    ):
+        value = policy.setdefault(key, [])
+        if not isinstance(value, list):
+            raise ValueError(f"chain policy {key} must be a list")
+        if not all(isinstance(item, dict) for item in value):
+            raise ValueError(f"chain policy {key} entries must be mappings")
+
+    if not policy["direct_free_fallbacks"]:
+        raise ValueError("chain policy requires at least one direct free fallback")
+    for rule in policy["blocked_models"]:
+        allowed_models = rule.get("allow_models", [])
+        if not isinstance(allowed_models, list) or not all(
+            isinstance(model, str) and model.strip() for model in allowed_models
+        ):
+            raise ValueError("chain policy allow_models must contain non-empty strings")
+    for fallback in policy["direct_free_fallbacks"]:
+        provider, model = _entry_values(fallback)
+        if blocked_reason(provider, model, policy):
+            raise ValueError(f"configured direct fallback is blocklisted: {provider}/{model}")
+    return policy
+
+
+def blocked_reason(provider: Any, model: Any, policy: Mapping[str, Any]) -> Optional[str]:
+    """Return why a candidate is excluded, or ``None`` when it is allowed."""
+    normalized_provider = _normalized(provider)
+    normalized_model = _model_component(model)
+
+    for rule in policy.get("blocked_providers", []):
+        blocked_provider = _normalized(rule.get("provider", ""))
+        if blocked_provider and normalized_provider == blocked_provider:
+            return str(rule.get("reason", "blocked provider"))
+
+    for rule in policy.get("blocked_provider_prefixes", []):
+        provider_prefix = _normalized(rule.get("prefix", ""))
+        if provider_prefix and normalized_provider.startswith(provider_prefix):
+            return str(rule.get("reason", "blocked provider prefix"))
+
+    for rule in policy.get("blocked_models", []):
+        rule_provider = _normalized(rule.get("provider", ""))
+        if not rule_provider or normalized_provider != rule_provider:
+            continue
+        exact_model = rule.get("model")
+        if exact_model is not None and normalized_model == _model_component(exact_model):
+            return str(rule.get("reason", "blocked model"))
+        model_prefix = rule.get("model_prefix")
+        normalized_prefix = _model_component(model_prefix) if model_prefix is not None else ""
+        if not normalized_prefix or not normalized_model.startswith(normalized_prefix):
+            continue
+        allowed_models = rule.get("allow_models", [])
+        if any(normalized_model == _model_component(allowed) for allowed in allowed_models):
+            continue
+        return str(rule.get("reason", "blocked model prefix"))
+    return None
+
+
+def _direct_fallback(policy: Mapping[str, Any]) -> Dict[str, str]:
+    for fallback in policy.get("direct_free_fallbacks", []):
+        provider, model = _entry_values(fallback)
+        if not blocked_reason(provider, model, policy):
+            return {"provider": provider, "model": model}
+    raise ValueError("chain policy has no allowed direct free fallback")
+
+
+def _has_direct_fallback(entries: Iterable[Mapping[str, Any]], policy: Mapping[str, Any]) -> bool:
+    direct_keys = {
+        candidate_key(*_entry_values(fallback))
+        for fallback in policy.get("direct_free_fallbacks", [])
+    }
+    return any(candidate_key(*_entry_values(entry)) in direct_keys for entry in entries)
+
+
+def validate_chain(entries: Iterable[Mapping[str, Any]], policy: Mapping[str, Any]) -> None:
+    """Raise when a chain still violates its membership safety invariants."""
+    entries = list(entries)
+    if not entries:
+        raise ValueError("fallback chain cannot be empty")
+    if not _has_direct_fallback(entries, policy):
+        raise ValueError("fallback chain has no direct free fallback")
+    for entry in entries:
+        provider, model = _entry_values(entry)
+        reason = blocked_reason(provider, model, policy)
+        if reason:
+            raise ValueError(f"blocklisted fallback entry {provider}/{model}: {reason}")
+
+
+def sanitize_chain(
+    entries: Iterable[Mapping[str, Any]],
+    policy: Mapping[str, Any],
+    max_entries: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Filter a chain, retain entry metadata, and guarantee a direct fallback."""
+    if max_entries is not None and max_entries < 1:
+        raise ValueError("max_entries must be positive")
+
+    sanitized: List[Dict[str, Any]] = []
+    seen = set()
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            raise ValueError("fallback chain entries must be mappings")
+        provider, model = _entry_values(entry)
+        if blocked_reason(provider, model, policy):
+            continue
+        key = candidate_key(provider, model)
+        if key in seen:
+            continue
+        seen.add(key)
+        copied = dict(entry)
+        copied["provider"] = provider
+        copied["model"] = model
+        sanitized.append(copied)
+        if max_entries is not None and len(sanitized) >= max_entries:
+            break
+
+    if not _has_direct_fallback(sanitized, policy):
+        fallback = _direct_fallback(policy)
+        if max_entries is not None and len(sanitized) >= max_entries:
+            sanitized[-1] = fallback
+        else:
+            sanitized.append(fallback)
+
+    for priority, entry in enumerate(sanitized, start=1):
+        entry["priority"] = priority
+    validate_chain(sanitized, policy)
+    return sanitized

--- a/scripts/generate_virtual_models.py
+++ b/scripts/generate_virtual_models.py
@@ -11,13 +11,17 @@ Generates intelligent fallback chains for virtual models based on:
 Outputs: config/virtual_models_generated.yaml
 """
 
-import sys
-import yaml
-import requests
+import argparse
 import math
+import sys
 from pathlib import Path
-from typing import Dict, List, Any
 from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import requests
+import yaml
+
+from chain_policy import blocked_reason, load_policy, sanitize_chain
 
 PROJECT_ROOT = Path(__file__).parent.parent
 CONFIG_DIR = PROJECT_ROOT / "config"
@@ -286,7 +290,9 @@ def generate_fallback_chain(
     min_ugi: float = 0.0,
     min_ugi_entertainment: float = 0.0,
     max_hallucination: float = 100.0,
+    policy: Optional[Dict[str, Any]] = None,
 ) -> List[Dict]:
+    policy = policy or load_policy()
     scored = []
     for m in models:
         if min_intelligence > 0 and m.get("intelligence", 0) < min_intelligence:
@@ -317,23 +323,29 @@ def generate_fallback_chain(
     chain = []
     for m in scored:
         key = f"{m['provider']}/{m['model']}"
-        if key not in seen and m["provider"] in FREE_PROVIDERS:
-            seen.add(key)
-            chain.append(
-                {
-                    "provider": m["provider"],
-                    "model": m["model"],
-                    "priority": len(chain) + 1,
-                    "reasoning_effort": m.get("reasoning_effort", "None"),
-                }
-            )
+        if m["provider"] not in FREE_PROVIDERS:
+            continue
+        if blocked_reason(m["provider"], m["model"], policy):
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        chain.append(
+            {
+                "provider": m["provider"],
+                "model": m["model"],
+                "priority": len(chain) + 1,
+                "reasoning_effort": m.get("reasoning_effort", "None"),
+            }
+        )
         if len(chain) >= max_models:
             break
 
-    return chain
+    return sanitize_chain(chain, policy, max_entries=max_models)
 
 
-def generate_virtual_models_yaml() -> Dict:
+def generate_virtual_models_yaml(policy: Optional[Dict[str, Any]] = None) -> Dict:
+    policy = policy or load_policy()
     print("Loading ranking data...")
     coding_models = load_coding_models()
     chat_models = load_chat_models()
@@ -347,7 +359,7 @@ def generate_virtual_models_yaml() -> Dict:
 
     print("\nGenerating coding-elite...")
     chain = generate_fallback_chain(
-        coding_models, WEIGHTS["coding-elite"], "coding", min_score=0.5
+        coding_models, WEIGHTS["coding-elite"], "coding", min_score=0.5, policy=policy
     )
     virtual_models["coding-elite"] = {
         "description": "Best agentic coding models (SWE-bench + LiveCodeBench weighted)",
@@ -358,7 +370,7 @@ def generate_virtual_models_yaml() -> Dict:
 
     print("\nGenerating coding-smart...")
     chain = generate_fallback_chain(
-        coding_models, WEIGHTS["coding-smart"], "coding", min_score=0.35
+        coding_models, WEIGHTS["coding-smart"], "coding", min_score=0.35, policy=policy
     )
     virtual_models["coding-smart"] = {
         "description": "High-quality coding with balanced performance",
@@ -369,7 +381,7 @@ def generate_virtual_models_yaml() -> Dict:
 
     print("\nGenerating coding-fast...")
     chain = generate_fallback_chain(
-        coding_models, WEIGHTS["coding-fast"], "coding", min_score=0.3
+        coding_models, WEIGHTS["coding-fast"], "coding", min_score=0.3, policy=policy
     )
     virtual_models["coding-fast"] = {
         "description": "Fastest coding models (TPS priority with quality floor)",
@@ -380,7 +392,7 @@ def generate_virtual_models_yaml() -> Dict:
 
     print("\nGenerating chat-smart...")
     chain = generate_fallback_chain(
-        chat_models, WEIGHTS["chat-smart"], "chat", min_score=0.4
+        chat_models, WEIGHTS["chat-smart"], "chat", min_score=0.4, policy=policy
     )
     virtual_models["chat-smart"] = {
         "description": "Best intelligence-to-speed ratio (smart AND reasonably fast)",
@@ -391,7 +403,7 @@ def generate_virtual_models_yaml() -> Dict:
 
     print("\nGenerating chat-elite...")
     chain = generate_fallback_chain(
-        chat_models, WEIGHTS["chat-elite"], "chat", min_score=0.5
+        chat_models, WEIGHTS["chat-elite"], "chat", min_score=0.5, policy=policy
     )
     virtual_models["chat-elite"] = {
         "description": "Most intelligent models regardless of speed (pure intelligence ranking)",
@@ -408,6 +420,7 @@ def generate_virtual_models_yaml() -> Dict:
         min_score=0.3,
         min_intelligence=30.0,
         max_hallucination=25.0,
+        policy=policy,
     )
     virtual_models["chat-fast"] = {
         "description": "Fastest models that aren't stupid (TPS priority, min intelligence threshold)",
@@ -426,6 +439,7 @@ def generate_virtual_models_yaml() -> Dict:
             max_models=20,
             min_ugi=25.0,
             min_ugi_entertainment=15.0,
+            policy=policy,
         )
     else:
         chain = [
@@ -447,6 +461,12 @@ def generate_virtual_models_yaml() -> Dict:
     }
     print(f"  Generated {len(chain)} models")
 
+    for name, virtual_model in virtual_models.items():
+        limit = 20 if name == "chat-rp" else 30
+        virtual_model["fallback_chain"] = sanitize_chain(
+            virtual_model["fallback_chain"], policy, max_entries=limit
+        )
+
     providers = load_yaml("virtual_models.yaml").get("providers", {})
 
     output = {
@@ -465,20 +485,62 @@ def generate_virtual_models_yaml() -> Dict:
     return output
 
 
-def main():
+def merge_generated_virtual_models(live_document: Dict, generated_output: Dict) -> Dict:
+    """Merge generated chains without replacing live per-model settings."""
+    if not isinstance(live_document, dict):
+        raise ValueError("live virtual model config must be a mapping")
+    live_models = live_document.get("virtual_models", {})
+    if not isinstance(live_models, dict):
+        raise ValueError("live virtual_models must be a mapping")
+
+    merged = dict(live_document)
+    merged_models = dict(live_models)
+    generated_models = generated_output.get("virtual_models", {})
+    if not isinstance(generated_models, dict):
+        raise ValueError("generated virtual_models must be a mapping")
+    for name, generated_model in generated_models.items():
+        if not isinstance(generated_model, dict):
+            raise ValueError(f"generated {name} virtual model must be a mapping")
+        live_model = merged_models.get(name)
+        if isinstance(live_model, dict):
+            updated_model = dict(live_model)
+            if "fallback_chain" in generated_model:
+                updated_model["fallback_chain"] = generated_model["fallback_chain"]
+            merged_models[name] = updated_model
+        else:
+            merged_models[name] = dict(generated_model)
+    merged["virtual_models"] = merged_models
+    return merged
+
+
+def main(argv: Optional[List[str]] = None):
+    parser = argparse.ArgumentParser(description="Generate policy-safe virtual model chains")
+    parser.add_argument("--dry-run", action="store_true", help="generate but write no files")
+    parser.add_argument(
+        "--policy", type=Path, help="path to the fallback-chain exclusion policy"
+    )
+    parser.add_argument(
+        "--write-live",
+        action="store_true",
+        help="merge generated virtual models into config/virtual_models.yaml",
+    )
+    args = parser.parse_args(argv)
+
     print("=" * 70)
     print("VIRTUAL MODEL GENERATOR")
     print("=" * 70)
 
-    output = generate_virtual_models_yaml()
+    output = generate_virtual_models_yaml(load_policy(args.policy))
 
     output_path = CONFIG_DIR / "virtual_models_generated.yaml"
-    with open(output_path, "w") as f:
-        yaml.dump(
-            output, f, default_flow_style=False, sort_keys=False, allow_unicode=True
-        )
-
-    print(f"\n✓ Generated: {output_path}")
+    if args.dry_run:
+        print(f"\nDry run: would write {output_path}")
+    else:
+        with open(output_path, "w") as f:
+            yaml.safe_dump(
+                output, f, default_flow_style=False, sort_keys=False, allow_unicode=True
+            )
+        print(f"\nGenerated: {output_path}")
 
     print("\n" + "=" * 70)
     print("SUMMARY: TOP 5 MODELS PER VIRTUAL MODEL")
@@ -490,11 +552,26 @@ def main():
         for i, m in enumerate(chain, 1):
             print(f"  {i}. {m['provider']}/{m['model']}")
 
-    # Write output to file
-    output_path = PROJECT_ROOT / "config" / "virtual_models.yaml"
-    with open(output_path, "w") as f:
-        yaml.dump(output, f, default_flow_style=False, sort_keys=False)
-    print(f"\nWrote virtual models to {output_path}")
+    if args.write_live:
+        live_path = CONFIG_DIR / "virtual_models.yaml"
+        live_document = yaml.safe_load(live_path.read_text()) or {}
+        merged = merge_generated_virtual_models(live_document, output)
+        if merged == live_document:
+            print(f"\nLive config unchanged: {live_path}")
+        elif args.dry_run:
+            print(f"\nDry run: would merge generated models into {live_path}")
+        else:
+            backup_path = live_path.with_name(
+                f"{live_path.name}.bak-pre-generate-{datetime.now():%Y%m%dT%H%M%S}"
+            )
+            backup_path.write_text(live_path.read_text())
+            live_path.write_text(
+                yaml.safe_dump(merged, default_flow_style=False, sort_keys=False)
+            )
+            print(f"\nBacked up live config: {backup_path}")
+            print(f"Merged generated virtual models into {live_path}")
+    elif not args.dry_run:
+        print("\nLive config unchanged (use --write-live to merge generated models).")
 
     return 0
 

--- a/scripts/generate_virtual_models.py
+++ b/scripts/generate_virtual_models.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 import requests
 import yaml
 
-from chain_policy import blocked_reason, load_policy, sanitize_chain
+from chain_policy import blocked_reason, load_policy, sanitize_chain, write_yaml_atomic
 
 PROJECT_ROOT = Path(__file__).parent.parent
 CONFIG_DIR = PROJECT_ROOT / "config"
@@ -501,19 +501,21 @@ def merge_generated_virtual_models(live_document: Dict, generated_output: Dict) 
     for name, generated_model in generated_models.items():
         if not isinstance(generated_model, dict):
             raise ValueError(f"generated {name} virtual model must be a mapping")
-        live_model = merged_models.get(name)
-        if isinstance(live_model, dict):
-            updated_model = dict(live_model)
-            if "fallback_chain" in generated_model:
-                updated_model["fallback_chain"] = generated_model["fallback_chain"]
-            merged_models[name] = updated_model
-        else:
+        if name not in merged_models:
             merged_models[name] = dict(generated_model)
+            continue
+        live_model = merged_models[name]
+        if not isinstance(live_model, dict):
+            raise ValueError(f"live {name} virtual model must be a mapping")
+        updated_model = dict(live_model)
+        if "fallback_chain" in generated_model:
+            updated_model["fallback_chain"] = generated_model["fallback_chain"]
+        merged_models[name] = updated_model
     merged["virtual_models"] = merged_models
     return merged
 
 
-def main(argv: Optional[List[str]] = None):
+def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Generate policy-safe virtual model chains")
     parser.add_argument("--dry-run", action="store_true", help="generate but write no files")
     parser.add_argument(
@@ -536,10 +538,7 @@ def main(argv: Optional[List[str]] = None):
     if args.dry_run:
         print(f"\nDry run: would write {output_path}")
     else:
-        with open(output_path, "w") as f:
-            yaml.safe_dump(
-                output, f, default_flow_style=False, sort_keys=False, allow_unicode=True
-            )
+        write_yaml_atomic(output_path, output, allow_unicode=True)
         print(f"\nGenerated: {output_path}")
 
     print("\n" + "=" * 70)
@@ -565,9 +564,7 @@ def main(argv: Optional[List[str]] = None):
                 f"{live_path.name}.bak-pre-generate-{datetime.now():%Y%m%dT%H%M%S}"
             )
             backup_path.write_text(live_path.read_text())
-            live_path.write_text(
-                yaml.safe_dump(merged, default_flow_style=False, sort_keys=False)
-            )
+            write_yaml_atomic(live_path, merged)
             print(f"\nBacked up live config: {backup_path}")
             print(f"Merged generated virtual models into {live_path}")
     elif not args.dry_run:

--- a/scripts/rebuild_chains.py
+++ b/scripts/rebuild_chains.py
@@ -9,7 +9,13 @@ from typing import Any, Dict, Iterable, List, Mapping, Tuple
 
 import yaml
 
-from chain_policy import candidate_key, blocked_reason, load_policy, sanitize_chain
+from chain_policy import (
+    blocked_reason,
+    candidate_key,
+    load_policy,
+    sanitize_chain,
+    write_yaml_atomic,
+)
 
 
 DEFAULT_CONFIG = Path("/tmp/opencode/virtual_models.yaml")
@@ -169,14 +175,16 @@ def filter_new_tops_by_observed_models(
     }
     if not observed:
         return {}
-    return {
-        name: [
+    filtered = {}
+    for name, entries in new_tops.items():
+        observed_candidates = [
             (provider, model)
             for provider, model in entries
             if candidate_key(provider, model) in observed
         ]
-        for name, entries in new_tops.items()
-    }
+        if observed_candidates:
+            filtered[name] = observed_candidates
+    return filtered
 
 
 def rebuild_document(
@@ -245,7 +253,7 @@ def main(argv: List[str] | None = None) -> int:
 
     backup = args.config.with_name(f"{args.config.name}.bak-pre-rebuild")
     backup.write_text(args.config.read_text())
-    args.config.write_text(yaml.safe_dump(rebuilt, default_flow_style=False, sort_keys=False))
+    write_yaml_atomic(args.config, rebuilt)
     print(f"Backup: {backup}")
     print(f"Wrote: {args.config}")
     return 0

--- a/scripts/rebuild_chains.py
+++ b/scripts/rebuild_chains.py
@@ -1,126 +1,71 @@
 #!/usr/bin/env python3
-"""Rebuild chains in virtual_models.yaml with real working (provider, model) pairs at the top.
+"""Rebuild selected virtual-model chains without changing provider catalogs."""
 
-Inputs:
-- /tmp/opencode/working_models.json: dump from dump_alias_to_actual.py (provider -> [(model, n, ttft, tps), ...])
-- current virtual_models.yaml
-
-Strategy per chain:
-- For each chain, prepend 3-8 working models from telemetry that match the chain's purpose
-- Keep all existing entries (user rule: NEVER remove)
-- Renumber priorities
-
-For each chain we hand-pick the best working models based on:
-- Chain purpose (coding-* vs chat-*)
-- TTFT < 10s threshold
-- n >= 3 samples
-- Provider not in dead list
-"""
+import argparse
 import json
-import sys
-import re
 from collections import defaultdict
 from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
 
-# Dead providers to NEVER use as new entries (user confirmed these are dead)
-# Note: 'gemini' is RATE-LIMITED (429) but works when not rate-limited -- keep it
-DEAD_PROVIDERS = {
-    "cliproxyapi",  # manual OAuth, often broken
-    "supacoder",    # dead
-    "antigravity",  # unreliable OAuth
-    "blaze", "blaze_org", "blazeai",  # all 401
-    "agentrouter",  # 401
-    "aibz",         # blocked
-    "logfare",      # 500
-    "voidai",       # 500
-    "zenllm_responses",  # blocked
-    "free_gemini",  # 401
-    "openrouter",   # out of credits
-}
+import yaml
 
-# Working providers in priority order (user wants free-credit first, NVIDIA as backup)
-WORKING_FREE_TIER = {
-    "groq", "mistral", "cerebras", "nvidia",  # unlimited free
-    "koyeb", "koyeb-new",  # has free credit
-    "freetheai",  # daily checkin
-    "blaze-free",  # free tier
-    "iamhc", "paxsenix", "nianhua", "buddybackend",  # chinese gateways
-    "anmix", "tokenrouter", "tokenlb", "pooled",  # chinese gateways
-    "navy",  # chinese gateway
-    "zenllm-free",  # free tier
-    "futureppo",  # daily checkin
-    "kilocode", "kilo",  # free tier
-}
+from chain_policy import candidate_key, blocked_reason, load_policy, sanitize_chain
 
 
-def load_working_models(path="/tmp/opencode/working_models.json"):
-    """Load {provider: [(model, n, ttft, tps), ...]} from JSON dump.
+DEFAULT_CONFIG = Path("/tmp/opencode/virtual_models.yaml")
+DEFAULT_WORKING_MODELS = Path("/tmp/opencode/working_models.json")
 
-    Returns empty dict if file is missing (verification step is skipped).
-    """
+
+def load_working_models(path: Path, policy: Mapping[str, Any]) -> Dict[str, List[Dict]]:
+    """Load telemetry candidates, excluding only policy-blocked chain members."""
     try:
-        with open(path) as f:
-            raw = json.load(f)
+        raw = json.loads(path.read_text())
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
-    out = defaultdict(list)
+    if not isinstance(raw, list):
+        raise ValueError(f"working models must be a list: {path}")
+
+    working: Dict[str, List[Dict]] = defaultdict(list)
     for entry in raw:
-        provider = entry["provider"]
-        if provider in DEAD_PROVIDERS:
+        if not isinstance(entry, dict):
             continue
-        out[provider].append(entry)
-    return out
+        provider = entry.get("provider")
+        model = entry.get("model")
+        if not isinstance(provider, str) or not isinstance(model, str):
+            continue
+        if not blocked_reason(provider, model, policy):
+            working[provider].append(entry)
+    return dict(working)
 
 
-def is_good_coding_model(model, ttft, tps, n):
-    """Heuristic: is this a reasonable coding model?"""
-    if ttft > 30000:  # >30s TTFT is unusable
+def is_good_coding_model(model: str, ttft: float, tps: float, samples: int) -> bool:
+    """Return whether telemetry describes a usable coding candidate."""
+    if ttft > 30000 or samples < 2:
         return False
-    if n < 2:
-        return False
-    # Exclude models with 'rp' or 'uncensored' in name for coding chains
-    bad = ["rp", "uncensored", "roleplay", "flux", "sdxl", "dall-e", "imagen"]
-    return not any(b in model.lower() for b in bad)
+    banned_terms = ("rp", "uncensored", "roleplay", "flux", "sdxl", "dall-e", "imagen")
+    return not any(term in model.lower() for term in banned_terms)
 
 
-def is_good_chat_model(model, ttft, tps, n):
-    """Heuristic: is this a reasonable chat model?"""
-    if ttft > 30000:
-        return False
-    if n < 2:
-        return False
-    return True
+def is_good_chat_model(model: str, ttft: float, tps: float, samples: int) -> bool:
+    """Return whether telemetry describes a usable chat candidate."""
+    return ttft <= 30000 and samples >= 2
 
 
-def get_top_models(working, n, filter_fn):
-    """Return top-n models across all working providers, sorted by (tps desc, ttft asc)."""
-    all_models = []
+def get_top_models(
+    working: Mapping[str, Iterable[Dict]], count: int, filter_fn: Any
+) -> List[Tuple[str, Dict]]:
+    """Return fastest telemetry candidates across providers."""
+    candidates = []
     for provider, entries in working.items():
-        for e in entries:
-            if filter_fn(e["model"], e["ttft"], e["tps"], e["n"]):
-                all_models.append((provider, e))
-    # Sort by tps desc, ttft asc
-    all_models.sort(key=lambda x: (-x[1]["tps"], x[1]["ttft"]))
-    return all_models[:n]
+        for entry in entries:
+            if filter_fn(entry["model"], entry["ttft"], entry["tps"], entry["n"]):
+                candidates.append((provider, entry))
+    return sorted(candidates, key=lambda item: (-item[1]["tps"], item[1]["ttft"]))[:count]
 
 
-def get_top_models_for_provider(working, provider, n, filter_fn):
-    """Return top-n models for a specific provider."""
-    entries = working.get(provider, [])
-    entries = [e for e in entries if filter_fn(e["model"], e["ttft"], e["tps"], e["n"])]
-    entries.sort(key=lambda x: (-x["tps"], x["ttft"]))
-    return [(provider, e) for e in entries[:n]]
-
-
-def main():
-    yaml_path = Path(sys.argv[1] if len(sys.argv) > 1 else "/tmp/opencode/virtual_models.yaml")
-    working = load_working_models()
-
-    # Per-chain new top entries (provider, model) -- max 8 per chain to keep short
-    # ponytail: bare model names route through gateway provider list; openai/* prefix
-    # forces api.openai.com call which fails (no OPENAI_API_KEY). Use REAL provider names.
-    new_tops = {
-        # Coding chains: prefer groq (fast, reliable, large samples), then others
+def default_new_tops() -> Dict[str, List[Tuple[str, str]]]:
+    """Return bounded manual recovery candidates for the non-agent virtual models."""
+    return {
         "coding-fast": [
             ("groq", "llama-3.1-8b-instant"),
             ("groq", "llama-3.3-70b-versatile"),
@@ -159,7 +104,6 @@ def main():
             ("gemini", "gemini-2.5-flash"),
             ("aihubmix", "coding-minimax-m3-free"),
         ],
-        # Chat chains: prefer fast chat-tuned
         "chat-fast": [
             ("groq", "llama-3.1-8b-instant"),
             ("gemini", "gemini-2.5-flash"),
@@ -211,130 +155,101 @@ def main():
         ],
     }
 
-    # agent-* chains use github-models (which works) -- leave as-is
-    # oracle, explore, librarian, build, metis, momus - leave as-is
 
-    print("=== Plan ===")
-    for chain, entries in new_tops.items():
-        print(f"  {chain}: {len(entries)} new top entries")
-    print(f"  Total: {sum(len(v) for v in new_tops.values())} new entries")
-    print()
-    print("=== Verify all entries are in working set ===")
-    missing = 0
-    for chain, entries in new_tops.items():
-        for provider, model in entries:
-            in_working = any(
-                e["model"] == model for e in working.get(provider, [])
-            )
-            if not in_working:
-                print(f"  MISS: {chain}: {provider}/{model} not in telemetry")
-                missing += 1
-    if missing == 0:
-        print("  All entries verified in telemetry")
-    else:
-        print(f"  {missing} entries not in telemetry (will still add, but reorder will mark no_telemetry)")
+def filter_new_tops_by_observed_models(
+    new_tops: Mapping[str, Iterable[Tuple[str, str]]],
+    working: Mapping[str, Iterable[Mapping[str, Any]]],
+) -> Dict[str, List[Tuple[str, str]]]:
+    """Keep static recovery candidates only when current telemetry observed them."""
+    observed = {
+        candidate_key(provider, entry["model"])
+        for provider, entries in working.items()
+        for entry in entries
+        if isinstance(entry, Mapping) and isinstance(entry.get("model"), str)
+    }
+    if not observed:
+        return {}
+    return {
+        name: [
+            (provider, model)
+            for provider, model in entries
+            if candidate_key(provider, model) in observed
+        ]
+        for name, entries in new_tops.items()
+    }
 
-    # ============ APPLY: rebuild chains in virtual_models.yaml ============
-    import re
-    yaml_text = yaml_path.read_text()
 
-    def rebuild_chain(yaml_text, chain_name, new_entries):
-        """Find chain in yaml, prepend new entries, renumber all priorities.
+def rebuild_document(
+    document: Mapping[str, Any],
+    new_tops: Mapping[str, Iterable[Tuple[str, str]]],
+    policy: Mapping[str, Any],
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Return a target-only, policy-safe rebuild and names changed.
 
-        The yaml indent for fallback_chain entries is 4 spaces (    - provider:)
-        and the inner fields are 6 spaces (      model:,      priority:).
-        """
-        # Find the chain section
-        # Pattern matches 4-space-indent entries inside a chain
-        pattern = re.compile(
-            r"(  " + re.escape(chain_name) + r":\n"
-            r"(?:    [^\n]+\n)*?"  # description, settings, etc. (4-space lines)
-            r"    fallback_chain:\n"
-            r"(?:    - provider: [^\n]+\n"
-            r"      model: [^\n]+\n"
-            r"      priority: \d+\n"
-            r"(?:      [^\n]+\n)*)*)"
-        )
-        m = pattern.search(yaml_text)
-        if not m:
-            return yaml_text, False
-        old_block = m.group(1)
-        # Extract existing entries (4-space indent)
-        old_entries = re.findall(
-            r"    - provider: ([^\n]+)\n"
-            r"      model: ([^\n]+)\n"
-            r"      priority: \d+",
-            old_block,
-        )
-        # Find existing extras (capabilities, notes) per entry
-        old_extras = {}
-        for entry_match in re.finditer(
-            r"    - provider: ([^\n]+)\n"
-            r"      model: ([^\n]+)\n"
-            r"      priority: \d+\n"
-            r"((?:      [^\n]+\n)*)",
-            old_block,
-        ):
-            provider, model, extras = entry_match.groups()
-            old_extras[(provider, model)] = extras
+    Catalogs and unrelated virtual models are retained untouched.
+    """
+    if not isinstance(document, Mapping):
+        raise ValueError("virtual model config must be a mapping")
+    virtual_models = document.get("virtual_models")
+    if not isinstance(virtual_models, Mapping):
+        raise ValueError("virtual_models must be a mapping")
 
-        # Build new chain: prepend new_entries, then dedupe existing
-        seen = set()
-        merged = []
-        for provider, model in new_entries:
-            key = (provider, model)
-            if key in seen:
-                continue
-            seen.add(key)
-            merged.append((provider, model, "new"))
-        for provider, model in old_entries:
-            key = (provider, model)
-            if key in seen:
-                continue
-            seen.add(key)
-            merged.append((provider, model, "existing"))
+    rebuilt = dict(document)
+    rebuilt_models = dict(virtual_models)
+    changed = []
+    for name, entries in new_tops.items():
+        virtual_model = virtual_models.get(name)
+        if not isinstance(virtual_model, Mapping):
+            continue
+        existing_chain = virtual_model.get("fallback_chain", [])
+        if not isinstance(existing_chain, list):
+            raise ValueError(f"{name} fallback_chain must be a list")
+        candidates = [
+            {"provider": provider, "model": model} for provider, model in entries
+        ]
+        sanitized = sanitize_chain(candidates + existing_chain, policy)
+        updated_model = dict(virtual_model)
+        updated_model["fallback_chain"] = sanitized
+        if updated_model != virtual_model:
+            rebuilt_models[name] = updated_model
+            changed.append(name)
+    rebuilt["virtual_models"] = rebuilt_models
+    return rebuilt, changed
 
-        # Render with 4-space indent for `- provider:` and 6-space for inner fields (matches original)
-        lines = []
-        for i, (provider, model, kind) in enumerate(merged, 1):
-            extras = old_extras.get((provider, model), "")
-            lines.append(f"    - provider: {provider}\n")
-            lines.append(f"      model: {model}\n")
-            lines.append(f"      priority: {i}\n")
-            if extras:
-                lines.append(extras)
 
-        new_block_parts = old_block.rstrip("\n").split("\n")
-        # Find where fallback_chain entries start
-        fc_start = None
-        for i, line in enumerate(new_block_parts):
-            if "fallback_chain:" in line:
-                fc_start = i + 1
-                break
-        if fc_start is None:
-            return yaml_text, False
-        # Build new block: header (everything up to and including fallback_chain: line) + new entries
-        header = "\n".join(new_block_parts[:fc_start])
-        new_block = header + "\n" + "".join(lines) + "\n"
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Rebuild selected policy-safe fallback chains")
+    parser.add_argument("config", nargs="?", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--working-models", type=Path, default=DEFAULT_WORKING_MODELS)
+    parser.add_argument("--policy", type=Path)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
 
-        return yaml_text.replace(old_block, new_block), True
+    policy = load_policy(args.policy)
+    working = load_working_models(args.working_models, policy)
+    new_tops = filter_new_tops_by_observed_models(default_new_tops(), working)
+    print(f"Telemetry providers available: {len(working)}")
+    if not working:
+        print("No observed telemetry candidates; refusing static rebuild.")
+        return 0
+    document = yaml.safe_load(args.config.read_text()) or {}
+    rebuilt, changed = rebuild_document(document, new_tops, policy)
 
-    print()
-    print("=== Applying rebuild ===")
-    backup_path = yaml_path.with_suffix(yaml_path.suffix + ".bak-pre-rebuild")
-    backup_path.write_text(yaml_text)
-    print(f"  Backup: {backup_path}")
-    updated = yaml_text
-    for chain_name, entries in new_tops.items():
-        updated, ok = rebuild_chain(updated, chain_name, entries)
-        if ok:
-            print(f"  OK   {chain_name}: {len(entries)} new + existing")
-        else:
-            print(f"  SKIP {chain_name}: pattern not found")
+    if not changed:
+        print("No targeted chains changed.")
+        return 0
+    print(f"Policy-safe chains: {', '.join(changed)}")
+    if args.dry_run:
+        print(f"Dry run: would update {args.config}")
+        return 0
 
-    yaml_path.write_text(updated)
-    print(f"  Wrote: {yaml_path}")
+    backup = args.config.with_name(f"{args.config.name}.bak-pre-rebuild")
+    backup.write_text(args.config.read_text())
+    args.config.write_text(yaml.safe_dump(rebuilt, default_flow_style=False, sort_keys=False))
+    print(f"Backup: {backup}")
+    print(f"Wrote: {args.config}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_chain_policy.py
+++ b/tests/test_chain_policy.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from stat import S_IMODE
 
 import yaml
 
@@ -157,6 +158,29 @@ class TestChainPolicy(unittest.TestCase):
             coding_fast["fallback_chain"], [{"provider": "groq", "model": "new"}]
         )
 
+    def test_generated_merge_rejects_malformed_live_model(self) -> None:
+        with self.assertRaisesRegex(ValueError, "live coding-fast virtual model"):
+            generate_virtual_models.merge_generated_virtual_models(
+                {"virtual_models": {"coding-fast": "invalid"}},
+                {
+                    "virtual_models": {
+                        "coding-fast": {
+                            "fallback_chain": [{"provider": "groq", "model": "new"}]
+                        }
+                    }
+                },
+            )
+
+    def test_atomic_yaml_write_preserves_existing_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.yaml"
+            path.write_text("old: value\n")
+            path.chmod(0o640)
+            chain_policy.write_yaml_atomic(path, {"new": "value"})
+            self.assertEqual(yaml.safe_load(path.read_text()), {"new": "value"})
+            self.assertEqual(S_IMODE(path.stat().st_mode), 0o640)
+            self.assertFalse(list(Path(directory).glob(".config.yaml.*.tmp")))
+
 
 class TestRebuildChains(unittest.TestCase):
     @classmethod
@@ -212,12 +236,16 @@ class TestRebuildChains(unittest.TestCase):
         )
 
     def test_static_candidates_require_current_telemetry(self) -> None:
-        candidates = {"coding-fast": [("groq", "llama-3.3-70b-versatile"), ("mistral", "x")]}
+        candidates = {
+            "coding-fast": [("groq", "llama-3.3-70b-versatile"), ("mistral", "x")],
+            "chat-fast": [("gemini", "gemini-2.5-flash")],
+        }
         filtered = rebuild_chains.filter_new_tops_by_observed_models(
             candidates,
             {"groq": [{"model": "llama-3.3-70b-versatile"}, "malformed"]},
         )
         self.assertEqual(filtered, {"coding-fast": [("groq", "llama-3.3-70b-versatile")]})
+        self.assertNotIn("chat-fast", filtered)
         self.assertEqual(rebuild_chains.filter_new_tops_by_observed_models(candidates, {}), {})
 
     def test_rebuild_dry_run_creates_no_backup_or_write(self) -> None:

--- a/tests/test_chain_policy.py
+++ b/tests/test_chain_policy.py
@@ -1,0 +1,249 @@
+"""Hermetic coverage for non-destructive fallback-chain exclusions (#401)."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import chain_policy
+import generate_virtual_models
+import rebuild_chains
+
+
+class TestChainPolicy(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policy = chain_policy.load_policy()
+
+    def test_required_blocks_and_allowed_neighbors(self) -> None:
+        cases = (
+            ("kilo", "model", True),
+            ("kilocode", "model", False),
+            ("antigravity", "model", True),
+            ("g4f_nvidia", "model", True),
+            ("g4f", "model", False),
+            ("cliproxyapi", "gemini-3-pro", True),
+            ("cliproxyapi", "gemini-3-flash", False),
+            ("cliproxyapi", "gemini-3-flash-preview", True),
+            ("cliproxyapi", "gemini-2.5-flash", False),
+            ("cerebras", "qwen-3-235b-a22b-instruct-2507", True),
+            ("supacoder", "gpt-5.4", True),
+            ("gemini", "gemini-3-pro", True),
+            ("gemini", "gemini-3.1-pro", True),
+        )
+        for provider, model, blocked in cases:
+            with self.subTest(provider=provider, model=model):
+                self.assertEqual(
+                    chain_policy.blocked_reason(provider, model, self.policy) is not None,
+                    blocked,
+                )
+
+    def test_matching_is_case_insensitive_and_uses_model_component(self) -> None:
+        self.assertIsNotNone(
+            chain_policy.blocked_reason(
+                "CEREBRAS", "vendor/QWEN-3-235B-A22B-INSTRUCT-2507", self.policy
+            )
+        )
+        self.assertIsNone(
+            chain_policy.blocked_reason("KILOCODE", "model", self.policy)
+        )
+
+    def test_sanitize_filters_dedupes_and_preserves_metadata(self) -> None:
+        chain = chain_policy.sanitize_chain(
+            [
+                {"provider": "nvidia", "model": "model-a", "notes": "keep"},
+                {"provider": "kilo", "model": "dead"},
+                {"provider": "NVIDIA", "model": "MODEL-A"},
+                {"provider": "g4f_nvidia", "model": "dead"},
+            ],
+            self.policy,
+            max_entries=2,
+        )
+        self.assertEqual(len(chain), 2)
+        self.assertEqual(chain[0]["notes"], "keep")
+        self.assertEqual(
+            [(entry["provider"], entry["priority"]) for entry in chain],
+            [("nvidia", 1), ("groq", 2)],
+        )
+        self.assertEqual(chain[1]["model"], "llama-3.3-70b-versatile")
+
+    def test_sanitize_empty_chain_injects_direct_fallback(self) -> None:
+        chain = chain_policy.sanitize_chain([], self.policy)
+        self.assertEqual(
+            chain,
+            [
+                {
+                    "provider": "groq",
+                    "model": "llama-3.3-70b-versatile",
+                    "priority": 1,
+                }
+            ],
+        )
+
+    def test_direct_fallback_requires_full_model_identity(self) -> None:
+        chain = chain_policy.sanitize_chain(
+            [{"provider": "groq", "model": "vendor-a/llama-3.3-70b-versatile"}],
+            self.policy,
+        )
+        self.assertEqual(
+            [(entry["provider"], entry["model"]) for entry in chain],
+            [
+                ("groq", "vendor-a/llama-3.3-70b-versatile"),
+                ("groq", "llama-3.3-70b-versatile"),
+            ],
+        )
+
+    def test_generator_filters_candidates_before_cap(self) -> None:
+        models = [
+            {"id": "kilo/model", "swe_bench": 100},
+            {"id": "cerebras/qwen-3-235b-a22b-instruct-2507", "swe_bench": 99},
+            {"id": "groq/llama-3.3-70b-versatile", "swe_bench": 98},
+        ]
+        chain = generate_virtual_models.generate_fallback_chain(
+            models,
+            {"swe_bench": 1.0},
+            "coding",
+            min_score=0,
+            max_models=2,
+            policy=self.policy,
+        )
+        self.assertEqual(
+            [(entry["provider"], entry["model"]) for entry in chain],
+            [("groq", "llama-3.3-70b-versatile")],
+        )
+
+    def test_generated_merge_preserves_live_only_configuration(self) -> None:
+        live = {
+            "agent_profiles": {"agent": {"model": "keep"}},
+            "virtual_models": {
+                "agent-oracle": {"fallback_chain": [{"provider": "kilo", "model": "kept"}]},
+                "coding-fast": {
+                    "description": "old",
+                    "auto_continue_on_truncate": True,
+                    "default_max_tokens": 2048,
+                    "auto_route": {"keep": True},
+                    "settings": {"timeout_ms": 1000},
+                    "fallback_chain": [{"provider": "groq", "model": "old"}],
+                },
+            },
+        }
+        generated = {
+            "virtual_models": {
+                "coding-fast": {
+                    "description": "new",
+                    "settings": {"timeout_ms": 2},
+                    "fallback_chain": [{"provider": "groq", "model": "new"}],
+                }
+            }
+        }
+        merged = generate_virtual_models.merge_generated_virtual_models(live, generated)
+        self.assertEqual(merged["agent_profiles"], live["agent_profiles"])
+        self.assertEqual(merged["virtual_models"]["agent-oracle"], live["virtual_models"]["agent-oracle"])
+        coding_fast = merged["virtual_models"]["coding-fast"]
+        self.assertEqual(coding_fast["description"], "old")
+        self.assertTrue(coding_fast["auto_continue_on_truncate"])
+        self.assertEqual(coding_fast["default_max_tokens"], 2048)
+        self.assertEqual(coding_fast["auto_route"], {"keep": True})
+        self.assertEqual(coding_fast["settings"], {"timeout_ms": 1000})
+        self.assertEqual(
+            coding_fast["fallback_chain"], [{"provider": "groq", "model": "new"}]
+        )
+
+
+class TestRebuildChains(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policy = chain_policy.load_policy()
+
+    def test_rebuild_filters_target_only_and_preserves_other_data(self) -> None:
+        document = {
+            "metadata": {"owner": "keep"},
+            "providers": {"catalog": {"endpoint": "keep"}},
+            "agent_profiles": {"agent": {"model": "keep"}},
+            "virtual_models": {
+                "coding-fast": {
+                    "description": "target",
+                    "fallback_chain": [
+                        {"provider": "kilo", "model": "dead"},
+                        {"provider": "nvidia", "model": "kept", "notes": "metadata"},
+                    ],
+                },
+                "agent-oracle": {
+                    "fallback_chain": [{"provider": "kilo", "model": "catalog-only"}]
+                },
+            },
+        }
+        rebuilt, changed = rebuild_chains.rebuild_document(
+            document,
+            {
+                "coding-fast": [
+                    ("supacoder", "gpt-5.4"),
+                    ("kilocode", "allowed"),
+                    ("groq", "llama-3.3-70b-versatile"),
+                ]
+            },
+            self.policy,
+        )
+        self.assertEqual(changed, ["coding-fast"])
+        chain = rebuilt["virtual_models"]["coding-fast"]["fallback_chain"]
+        self.assertEqual(
+            [(entry["provider"], entry["model"]) for entry in chain],
+            [
+                ("kilocode", "allowed"),
+                ("groq", "llama-3.3-70b-versatile"),
+                ("nvidia", "kept"),
+            ],
+        )
+        self.assertEqual(chain[-1]["notes"], "metadata")
+        self.assertEqual(rebuilt["metadata"], document["metadata"])
+        self.assertEqual(rebuilt["providers"], document["providers"])
+        self.assertEqual(rebuilt["agent_profiles"], document["agent_profiles"])
+        self.assertEqual(
+            rebuilt["virtual_models"]["agent-oracle"],
+            document["virtual_models"]["agent-oracle"],
+        )
+
+    def test_static_candidates_require_current_telemetry(self) -> None:
+        candidates = {"coding-fast": [("groq", "llama-3.3-70b-versatile"), ("mistral", "x")]}
+        filtered = rebuild_chains.filter_new_tops_by_observed_models(
+            candidates,
+            {"groq": [{"model": "llama-3.3-70b-versatile"}, "malformed"]},
+        )
+        self.assertEqual(filtered, {"coding-fast": [("groq", "llama-3.3-70b-versatile")]})
+        self.assertEqual(rebuild_chains.filter_new_tops_by_observed_models(candidates, {}), {})
+
+    def test_rebuild_dry_run_creates_no_backup_or_write(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "virtual_models.yaml"
+            original = {
+                "virtual_models": {
+                    "coding-fast": {
+                        "fallback_chain": [{"provider": "kilo", "model": "dead"}]
+                    }
+                }
+            }
+            config.write_text(yaml.safe_dump(original, sort_keys=False))
+            before = config.read_bytes()
+            result = rebuild_chains.main(
+                [
+                    str(config),
+                    "--working-models",
+                    str(Path(directory) / "missing.json"),
+                    "--dry-run",
+                ]
+            )
+            self.assertEqual(result, 0)
+            self.assertEqual(config.read_bytes(), before)
+            self.assertFalse(list(Path(directory).glob("*.bak-pre-rebuild")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
- Adds an auditable, chain-only dead-candidate policy; catalog and benchmark records stay intact.
- Gates generated and rebuilt fallback members, preserves live virtual-model settings, and requires a direct free fallback.
- Makes rebuilds telemetry-gated and dry-run safe.

## Verification
- Focused pytest: 30 passed, 1 unrelated warning.
- Python compile check passed.
- VPS-40 source-only deployment: compile plus copied-config dry run; live config hash unchanged.

## Note
Full suite still has pre-existing collection failures because litellm is unavailable.

Refs #401