### PR TITLE
fix(router): skip keyless fallback candidates

### DIFF
--- a/src/proxy_app/router_core.py
+++ b/src/proxy_app/router_core.py
@@ -853,6 +853,16 @@ class RouterCore:
         self, candidate_cfg: Dict[str, Any], provider: str, model: str
     ) -> bool:
         """Check rate limits AND credit exhaustion for a candidate."""
+        provider_cfg = self.config.get("providers", {}).get(provider, {})
+        api_key = self._resolve_llm_api_key(candidate_cfg, provider)
+        if (
+            provider_cfg.get("env_var")
+            and not provider_cfg.get("no_api_key_required", False)
+            and not api_key
+        ):
+            logger.info("Skipping %s/%s: API key unavailable", provider, model)
+            return False
+
         limits = self._compute_rate_limits(provider, model, candidate_cfg)
 
         can_use = await self.rate_limiter.can_use_provider(provider, model, limits)
@@ -863,7 +873,6 @@ class RouterCore:
             return False
 
         # Credit / quota exhaustion check (task-board #290 Phase 2).
-        api_key = self._resolve_llm_api_key(candidate_cfg, provider)
         if not self._check_credit_exhaustion(candidate_cfg, provider, api_key):
             logger.info(
                 f"Skipping {provider}/{model}: credits exhausted (will retry after daily reset)"

--- a/tests/test_router_core.py
+++ b/tests/test_router_core.py
@@ -174,6 +174,46 @@ class TestProviderCandidate:
         assert not candidate_no_structured.matches_requirements(req)
 
 
+class TestCandidateCredentials:
+    @pytest.fixture
+    def credential_router(self, tmp_path):
+        config = {
+            "free_only_mode": True,
+            "providers": {
+                "keyed": {"env_var": "KEYED_API_KEY", "free_tier": True},
+                "anonymous": {
+                    "env_var": "OPTIONAL_API_KEY",
+                    "no_api_key_required": True,
+                    "free_tier": True,
+                },
+            },
+        }
+        config_file = tmp_path / "router_config.yaml"
+        config_file.write_text(yaml.safe_dump(config))
+        return RouterCore(str(config_file))
+
+    @pytest.mark.asyncio
+    async def test_skips_configured_provider_without_key(
+        self, credential_router, monkeypatch
+    ):
+        monkeypatch.delenv("KEYED_API_KEY", raising=False)
+        assert not await credential_router._check_conditions({}, "keyed", "model")
+
+    @pytest.mark.asyncio
+    async def test_allows_configured_provider_with_key(
+        self, credential_router, monkeypatch
+    ):
+        monkeypatch.setenv("KEYED_API_KEY", "test-key")
+        assert await credential_router._check_conditions({}, "keyed", "model")
+
+    @pytest.mark.asyncio
+    async def test_allows_explicit_anonymous_provider(
+        self, credential_router, monkeypatch
+    ):
+        monkeypatch.delenv("OPTIONAL_API_KEY", raising=False)
+        assert await credential_router._check_conditions({}, "anonymous", "model")
+
+
 class TestErrorClassification:
     """Test error classification logic."""
 


### PR DESCRIPTION
## Summary

Virtual-model fallback chains iterate providers whose `env_var` declares a required API key that resolves to `None`, executing the adapter with `api_key=None` and producing a terminal `invalid key: EMPTY` error after exhausting every stale/keyless candidate. The stream fallback then returns only the last (misleading) error, hiding the real earlier failures.

Examples from current `coding-fast` chain (33 candidates): `freetheai`, `futureppo`, `kilocode`, `tokenrouter`, `pooled`, `blaze-free`, `iamhc`, `koyeb-new`, `cliproxyapi`, `aihubmix` — all declared `env_var` keys absent in `~/.env`. Direct authenticated curl from VPS-155 returns PONG, so caller key/route are sound; this is a gateway chain-health issue.

## Fix

Gate `_check_conditions` to skip a candidate BEFORE the rate limiter / adapter when:
- provider config declares `env_var`
- provider config does not set `no_api_key_required: true`
- the resolved key is empty

Preserves:
- Providers without `env_var` (backwards compat / public routes)
- Explicit anonymous providers (`no_api_key_required: true`, e.g. `g4f_*`)
- Groq/Gemini/Kilo special fallback key resolution
- Direct-model code path (intentionally conservative scope — addresses the virtual-chain failure mechanism)

## Testing

`TestCandidateCredentials` (3 async tests, no network). Verified locally against the actual service venv (has `litellm` installed):
```
1) keyed no-key   -> False (expect False)
2) keyed with-key -> True (expect True)
3) anonymous       -> True (expect True)
PASS all credential-gate checks
```

Gitleaks clean. No secrets logged (only provider/model name).

Refs #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Providers requiring an API key are now skipped when the key is unavailable, preventing unsuccessful routing attempts.
  * Providers explicitly configured to operate without an API key continue to be considered.
  * Routing now handles provider credentials more reliably before applying quota and rate-limit checks.

* **Tests**
  * Added coverage for providers with missing, available, and optional API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->