### PR TITLE
docs(bundle): harden gateway starter kit (#416 Step 1+2)

### DIFF
--- a/gumroad-bundle/.env.starter
+++ b/gumroad-bundle/.env.starter
@@ -1,149 +1,28 @@
-# ==============================================================================
-# Free LLM Gateway - Starter Config
-# Bundle: gumroad-bundle/.env.starter
-# ==============================================================================
+# Free LLM Gateway - starter environment
 #
-# INSTRUCTIONS:
-#   1. Copy this file to .env :  cp gumroad-bundle/.env.starter .env
-#   2. chmod 600 .env            (only your user can read it)
-#   3. Fill in every "# TODO" line with your free key from the linked URL.
-#   4. At minimum, fill in GROQ_API_KEY_1 and GEMINI_API_KEY_1 (two keys = working
-#      gateway with fallback). The rest add more fallback headroom.
-#   5. Set PROXY_API_KEY to any strong password you make up -- this is the key
-#      your coding tools (opencode/Cursor/continue.dev) will use to call YOUR
-#      gateway. It is NOT a provider key.
-#   6. Run:  bash gumroad-bundle/quickstart.sh
-#
-# Every provider below has a FREE tier. You do not need a credit card for any of
-# them (except Oracle Cloud, which verifies identity but never bills the Always
-# Free tier). See SETUP_GUIDE.md Step 2 for the full provider table + signup links.
-# ==============================================================================
+# Copy this file to .env, run chmod 600 .env, then fill in only credentials for
+# provider accounts you control. Provider availability, eligibility, limits, and
+# pricing can change; review each provider's current terms before adding a key.
 
+# Required: protect the gateway itself. Generate a value locally:
+#   openssl rand -hex 32
+# Paste the result between the quotes. An empty value disables gateway auth and
+# is unsupported by this setup.
+PROXY_API_KEY=""
 
-# ------------------------------------------------------------------------------
-# [REQUIRED] Proxy authentication - the key YOUR tools use to call YOUR gateway
-# ------------------------------------------------------------------------------
-# Make up any long random string. This is NOT a provider key; it is the password
-# that gates access to your gateway. Put it in your opencode/Cursor config.
-PROXY_API_KEY="change-this-to-a-strong-password-12345"
+# Add credentials only after checking the matching provider configuration in
+# config/router_config.yaml. Keep unused credentials out of this file.
 
-
-# ------------------------------------------------------------------------------
-# [RECOMMENDED - START HERE] Free providers with generous limits
-# ------------------------------------------------------------------------------
-
-# Groq - fastest free coding models, ~30 req/min. Start here.
-# TODO: fill in your free key from https://console.groq.com/keys
-GROQ_API_KEY_1=""
-
-# Google Gemini - good free tier, ~15 req/min.
-# TODO: fill in your free key from https://aistudio.google.com/apikey
-GEMINI_API_KEY_1=""
-
-# OpenRouter - aggregator; pick the ":free" models. Free tier, no card.
-# TODO: fill in your free key from https://openrouter.ai/keys
-OPENROUTER_API_KEY_1=""
-
-# Cerebras - extremely fast inference, 1M tokens/day free.
-# TODO: fill in your free key from https://cloud.cerebras.ai
-# (If this env var name is not picked up, check config/router_config.yaml for
-#  the exact credential key name your gateway version expects.)
-CEREBRAS_API_KEY_1=""
-
-
-# ------------------------------------------------------------------------------
-# [OPTIONAL] More free providers = more fallback headroom
-# ------------------------------------------------------------------------------
-# Each additional working key spreads load so a single provider rate-limit
-# never reaches you. Uncomment and fill in whichever you sign up for.
-
-# NVIDIA NIM - many open models, 40 req/min free.
-# TODO: fill in your free key from https://build.nvidia.com
-# NVIDIA_API_KEY=""
-
-# Mistral - La Plateforme free tier, Codestral good for code.
-# TODO: fill in your free key from https://console.mistral.ai
-# MISTRAL_API_KEY=""
-
-# iFlow - free DeepSeek models via Chinese aggregator.
-# TODO: fill in your free key from https://iflow.cn (WeChat or Chinese phone)
-# IFLOW_API_KEY_1=""
-
-# SambaNova - free open-model inference.
-# TODO: fill in your free key from https://sncloud.sambanova.ai
-# SAMBANOVA_API_KEY=""
-
-
-# ------------------------------------------------------------------------------
-# [OPTIONAL] Paid providers - only if you want them in the fallback chain
-# ------------------------------------------------------------------------------
-# The gateway is free-first by default (FREE_ONLY_MODE=true below). To let paid
-# providers participate, set FREE_ONLY_MODE=false AND add their keys here.
-# Your bill stays at zero unless you explicitly change FREE_ONLY_MODE.
-
-# TODO (optional, paid): https://platform.openai.com
-# OPENAI_API_KEY_1=""
-
-# TODO (optional, paid): https://console.anthropic.com
-# ANTHROPIC_API_KEY_1=""
-
-
-# ------------------------------------------------------------------------------
-# [G4F] Free fallback layer (advanced - only if you run G4F proxy endpoints)
-# ------------------------------------------------------------------------------
-# G4F provides free access to LLM providers as last-resort fallbacks. Leave
-# blank unless you have set up G4F proxy endpoints. Safe to ignore.
-G4F_API_KEY=""
-G4F_MAIN_API_BASE=""
-G4F_GROQ_API_BASE=""
-G4F_GEMINI_API_BASE=""
-
-
-# ------------------------------------------------------------------------------
-# [GATEWAY CONTROL] How the gateway behaves - safe defaults, rarely changed
-# ------------------------------------------------------------------------------
-
-# Free-only mode (default true): reject non-free providers so you never get an
-# accidental bill. Set to false only after adding paid keys above.
-FREE_ONLY_MODE=true
-
-# Dynamic chain re-ranking (default false): when true, the router re-orders
-# fallback chains from live telemetry (fastest providers first). Leave false for
-# the static chains in config/virtual_models.yaml. Enable after you have run the
-# reorder service for a while and want self-optimization.
+# Runtime options. These do not replace router policy in config/router_config.yaml.
 USE_DYNAMIC_CHAIN=false
-
-# Telemetry database path. /dev/shm is tmpfs (RAM-backed, fast, wiped on reboot).
-# If you want telemetry to survive reboots, point this at an on-disk path instead.
 TELEMETRY_DB_PATH="/dev/shm/telemetry.db"
-
-# Retry the whole fallback chain on hard failure with backoff (2s/4s/8s, max 3).
-# Leave false; the per-provider fallback already handles most failures.
 GATEWAY_RETRY_UNTIL_DONE=false
-
-# Ignore cooldown state and try all candidates. Leave false; cooldowns exist to
-# avoid hammering a rate-limited provider.
 GATEWAY_FORCE_TRY_COOLDOWN=false
-
-
-# ------------------------------------------------------------------------------
-# [PERFORMANCE] Per-key concurrency caps - safe defaults for free tiers
-# ------------------------------------------------------------------------------
-# These prevent one key from bursting past a provider's rate limit. Leave as-is
-# unless a provider's free tier allows more.
 MAX_CONCURRENT_REQUESTS_PER_KEY_GROQ=5
 MAX_CONCURRENT_REQUESTS_PER_KEY_GEMINI=1
 MAX_CONCURRENT_REQUESTS_PER_KEY_OPENAI=3
-
-# Rotation mode: balanced = spread load across keys, sequential = use one until
-# exhausted then move on. balanced is better for free tiers.
 ROTATION_MODE_GROQ=balanced
 ROTATION_MODE_OPENAI=balanced
-
-
-# ------------------------------------------------------------------------------
-# [ADVANCED] Model filtering - leave empty to use all available models
-# ------------------------------------------------------------------------------
 IGNORE_MODELS_GEMINI=""
 IGNORE_MODELS_OPENAI=""
 WHITELIST_MODELS_GEMINI=""

--- a/gumroad-bundle/CHANGELOG.md
+++ b/gumroad-bundle/CHANGELOG.md
@@ -1,39 +1,18 @@
 # Changelog -- Free LLM Gateway Starter Kit
 
-All notable changes to this Gumroad bundle are documented here. The underlying
-gateway repo (github.com/ons96/LLM-API-Key-Proxy) has its own changelog; this
-file tracks the bundle itself (the setup guide, templates, and scripts).
-
-Format: [Keep a Changelog](https://keepachangelog.com/), semantic versioning.
+This file tracks the buyer archive only. The gateway source has its own history.
 
 ## [1.0.0] - 2026-07-16
 
-### Added
-- `SETUP_GUIDE.md` -- the main deliverable. A 30-minute, step-by-step guide
-  from Oracle Cloud signup to a working free LLM gateway to pointing coding
-  tools (opencode, Cursor, continue.dev, LangChain) at it. Includes a
-  troubleshooting section covering the common first-boot failures (port not
-  open, 401, rate-limit fallback, OOM on 1GB, model name typos).
-- `.env.starter` -- sanitized config template. Every env var a buyer needs,
-  pre-filled with safe defaults and `# TODO` markers for free provider keys.
-  No internal paths, no leaked secrets, no VPS-specific values.
-- `quickstart.sh` -- one-click setup script. Installs uv + Python 3.12, creates
-  a venv, installs deps, writes a systemd service (auto-restart, MemoryMax=400M
-  for 1GB VPS safety), starts the gateway, runs a smoke test. Idempotent.
-- `GUMROAD_LISTING.md` -- the Gumroad product page copy (title, tagline, two-tier
-  pricing, FAQ, honest expectations).
-- `README.md` -- this bundle's README (what the directory is, how to zip for
-  Gumroad, file list).
+### Included
+- Secure setup guide, sanitized environment template, loopback-only installer,
+  unpublished listing draft, and explicit package script.
+- Local smoke-test and troubleshooting instructions for a self-hosted gateway.
 
-### Pricing
-- Standard tier: $29 (guide + templates + script + 30-day email support).
-- Bonus tier: $49 (adds the auto-optimizing reorder service that re-ranks
-  fallback chains from live telemetry every 30 minutes).
-
-### Notes
-- The underlying gateway repo is public and open source. The bundle's value is
-  the curated setup path, not the code.
-- All providers referenced (Groq, Gemini, Cerebras, OpenRouter, NVIDIA NIM,
-  Mistral, iFlow, SambaNova) have free tiers as of 2026-07. Provider limits and
-  availability can change; the guide's troubleshooting covers rate-limit
-  fallback behavior.
+### Product scope
+- One one-time product: USD 19 for the first 10 completed purchases or first
+  14 calendar days after launch, whichever comes first; USD 29 thereafter.
+- Published v1.x bundle updates only. No hosting, provider accounts, personal
+  support, service-level commitment, or future-major-version entitlement.
+- Provider, hosting, marketplace, quota, and pricing terms are external and
+  may change. Buyers are responsible for accounts and charges they control.

--- a/gumroad-bundle/GUMROAD_LISTING.md
+++ b/gumroad-bundle/GUMROAD_LISTING.md
@@ -1,170 +1,83 @@
-# GUMROAD LISTING - Free LLM Gateway Starter Kit
+# Product listing draft -- Free LLM Gateway Starter Kit
 
-> This is the copy for the Gumroad product page. Paste the sections below into
-> the Gumroad product editor. Keep the tone honest and practical.
+This is draft copy. Complete marketplace identity, payout, tax, refund, and
+launch-date fields manually before publishing.
 
----
+## Title
 
-## Product title
-
-Free LLM Gateway Starter Kit -- 9 Providers, 30-Minute Setup
+Free LLM Gateway Starter Kit -- Secure Self-Hosted Setup
 
 ## Tagline
 
-Your own always-on, OpenAI-compatible gateway that aggregates free LLM
-providers with automatic fallback. Zero monthly cost.
+Setup materials for running a loopback-only, OpenAI-compatible gateway from a
+source checkout you control.
 
 ## Price
 
-**$29** -- Standard tier (setup guide + templates + one-click script + 30-day email support)
+One one-time product. Charge USD 19 for the first 10 completed purchases or
+the first 14 calendar days after launch, whichever comes first, then USD 29.
+Immediately before publishing, add the exact UTC launch deadline to the product
+page. Keep the same price across checkout platforms; taxes and currency
+conversion can vary at checkout.
 
-**$49** -- Bonus tier (everything above + the auto-optimizing reorder service
-that re-ranks your fallback chains from live speed data every 30 minutes)
+## What buyers receive
 
-### Why two tiers
-The standard tier gets you a working free gateway in 30 minutes. The bonus tier
-adds a self-optimizing layer: a systemd timer that reads your gateway's
-telemetry and rewrites the fallback chains to favor whichever free providers are
-actually fastest for you right now. Over a few days, your `coding-elite` chain
-quietly tunes itself. If you are comfortable on the command line and want the
-gateway to get better on its own, get the bonus tier. If you just want it
-working and forget about it, the standard tier is enough.
+- A security-first installation guide for Ubuntu/Debian.
+- A sanitized `.env` template with no real credentials.
+- An idempotent systemd installer that binds the gateway to `127.0.0.1` only.
+- SSH-tunnel and optional HTTPS reverse-proxy guidance.
+- Local health and authenticated model-list smoke tests.
+- An explicit release script that packages only these buyer-facing files.
 
-## What you get
-
-- **The 30-minute setup guide** (`SETUP_GUIDE.md`) -- step-by-step, from Oracle
-  Cloud signup to a working gateway to pointing your coding tools at it. No
-  assumed knowledge beyond basic terminal use.
-- **Sanitized config template** (`.env.starter`) -- every env var you need,
-  pre-filled with safe defaults and clear `# TODO` markers for your free keys.
-  No internal paths, no leaked secrets, no guesswork.
-- **One-click setup script** (`quickstart.sh`) -- run it on your VPS; it installs
-  deps, writes the systemd service (auto-restart on crash, memory-capped for 1GB
-  VPS), starts the gateway, and runs a smoke test. Idempotent -- safe to re-run.
-- **Virtual model config** -- the four virtual models (`coding-elite`,
-  `coding-fast`, `chat-smart`, `chat-fast`) backed by deep fallback chains, ready
-  to use the moment the gateway boots.
-- **Tool integration examples** -- working config snippets for opencode, Cursor,
-  continue.dev, and LangChain so you can point your tools at the gateway in
-  under a minute.
-- **30 days of email support** -- stuck on a step? Email with your redacted
-  `.env` and log output; response within 2 business days.
-- **Bonus tier only: the reorder service** -- systemd unit + timer that
-  re-optimizes your fallback chains from live telemetry every 30 minutes.
-
-## Who it's for
-
-- Developers who want free LLMs for coding and chat without stitching nine
-  provider accounts into their tools by hand.
-- opencode, Cursor, and continue.dev users who want a single custom OpenAI
-  endpoint instead of juggling provider configs.
-- Hobbyists and indie hackers who want an always-on LLM endpoint for side
-  projects without a monthly bill.
-- Anyone on a tight budget who has heard "just use free LLM providers" but
-  bounced off the setup complexity.
-
-## What it saves you
-
-The underlying gateway is open source and free. What you are paying for is the
-hours this bundle removes:
-
-- Reading a large repo to figure out which env vars matter and which are
-  internal noise.
-- Signing up for nine providers and not knowing which two are enough to start.
-- Debugging the first boot (port not open, wrong key format, OOM on 1GB,
-  virtual model name typo) -- the troubleshooting section covers each.
-- Writing a systemd unit that survives reboots and does not OOM your VPS.
-- Figuring out how to point opencode/Cursor/continue.dev at a custom endpoint.
-
-If your time is worth more than about $6/hour to you, the standard tier pays for
-itself in the first afternoon.
+The source repository is public at
+`https://github.com/ons96/LLM-API-Key-Proxy`. This product sells curated setup
+materials, not exclusive source access. Gateway source licensing remains
+separate: the proxy application is MIT and the rotator library is LGPL-3.0.
 
 ## Requirements
 
-- An Oracle Cloud account (Always Free tier, credit card for identity verify
-  only -- never billed for free-tier resources).
-- 2 to 5 free LLM provider API keys (Groq + Gemini minimum; all free, links in
-  the guide). About 10 minutes of signup.
-- Basic terminal comfort (SSH in, edit a file, run a script). No Python or
-  networking expertise needed.
+- A source checkout of the gateway and an Ubuntu/Debian host where you have
+  normal-user sudo access.
+- Provider credentials and hosting accounts controlled by the buyer.
+- Basic command-line comfort: SSH, editing a file, and running a script.
+- A personal SSH tunnel or, for public use, a domain and separately configured
+  HTTPS reverse proxy.
+
+Provider, hosting, marketplace, quota, eligibility, and pricing terms can
+change. Review current third-party terms before creating an account or adding a
+credential. This bundle does not promise a particular provider, model, rate
+limit, cost, uptime, or result.
+
+## Security model
+
+The installer keeps the gateway on `127.0.0.1:8000`. It does not open a
+firewall port or print a public HTTP endpoint. For remote personal use, tunnel
+the port over SSH. For internet-facing use, configure HTTPS on ports 80/443 and
+reverse-proxy only to the loopback gateway. Keep `PROXY_API_KEY` enabled in all
+cases. Never upload or send `.env` files, provider keys, or proxy keys.
+
+## Product scope
+
+Buyers receive published v1.x updates to these bundle materials. Purchase does
+not include hosting, provider accounts, API keys, a service-level commitment,
+personal support, or a future major version. Configure any refund policy in the
+checkout platform before launch; do not condition refunds on private support.
 
 ## FAQ
 
-**Is the gateway code free?**
-Yes. It is open source at github.com/ons96/LLM-API-Key-Proxy and always will be.
+**Does this include hosted API access?** No. It is a self-hosted setup bundle.
 
-**Then what am I paying for?**
-The curated 30-minute setup path, the sanitized config template, the one-click
-script, the tool-integration examples, and 30 days of email support. You are
-buying convenience and curation, not the code -- like a book that explains free
-software.
+**Can I expose port 8000 directly?** No. Keep it loopback-only; use SSH or a
+properly configured HTTPS reverse proxy.
 
-**Will it cost me anything ongoing?**
-No. All providers have free tiers. The gateway is free-first by default
-(`FREE_ONLY_MODE=true`), so even if you add a paid key later it will not use it
-unless you explicitly turn that off.
+**Will every configured provider work?** No guarantee. Credentials, models,
+quotas, and upstream availability are external and can change.
 
-**What if a provider rate-limits me?**
-The gateway automatically falls back to the next provider in the chain. You
-usually never see the failure. Adding more free keys spreads the load.
+**What do I test first?** Run the local `/health` and authenticated `/v1/models`
+checks, then point one client through an SSH tunnel before considering HTTPS.
 
-**Can I add paid providers later?**
-Yes. Drop an OpenAI or Anthropic key in `.env`, set `FREE_ONLY_MODE=false`, and
-they join the fallback chains. The free-first ordering keeps your bill at zero
-unless you change it.
+## Honest expectations
 
-**Does it work on a 1GB VPS?**
-Yes. The systemd unit is memory-capped at 400MB and the gateway is designed for
-low-RAM hardware. If you pick the 6GB ARM free shape, you can raise the cap.
-
-**Is my gateway exposed to the internet?**
-Only if you choose to open the port that wide. The guide shows you how to lock
-access to your IP or use Tailscale (free, private VPN) so only your devices can
-reach it.
-
-**What if I get stuck?**
-Email the address in your Gumroad receipt with what you expected, what happened,
-the error, and your `.env` with key values replaced by `XXXX`. Response within 2
-business days, 30 days from purchase.
-
-**Is there a refund?**
-If you cannot get the gateway running after contacting support, yes -- full
-refund within 30 days. We want this to actually work for you.
-
-## Sample (first page of the setup guide)
-
-```
-What you're building
---------------------
-You are about to set up your own free OpenAI-compatible LLM gateway on a
-tiny cloud server. Instead of juggling nine different provider accounts and
-hardcoding each one into your coding tools, you point your tools at one URL
-and the gateway does the rest:
-
-- It speaks the OpenAI API (/v1/chat/completions, /v1/models), so any tool
-  that accepts a custom OpenAI base URL works immediately.
-- It exposes a handful of virtual models -- coding-elite, coding-fast,
-  chat-smart, chat-fast -- each backed by a fallback chain of free
-  providers. If Groq is rate-limited, it silently tries Cerebras, then
-  Gemini, and so on. You never see the failure.
-- It runs on a 1 GB Oracle Cloud free-tier VM, costs $0/month, and stays
-  up 24/7 (no sleep, unlike Render's free tier).
-
-The gateway code itself is open source and always will be. What you paid for
-is this curated 30-minute path, the pre-filled config template, the
-one-click setup script, and support.
-```
-
-## Honest expectations (include on the listing page)
-
-- Free tiers have rate limits. The gateway spreads load across providers so you
-  rarely hit a wall, but it is not "unlimited free LLMs forever." Heavy agentic
-  sessions may occasionally wait for a cooldown.
-- Quality varies by provider. `coding-elite` prefers the best free coding models
-  available; some (GLM-5.2, Gemini 3 Pro, Qwen3) are genuinely strong, but it is
-  not a paid Claude/GPT-tier experience.
-- The VPS is yours to maintain. Oracle occasionally restarts instances; systemd
-  brings the gateway back automatically. Apply OS updates now and then.
-
-No false scarcity. No "only 50 left." No countdown timer. This is a digital
-product that will be here when you are ready.
+This bundle removes setup ambiguity; it does not remove third-party account
+requirements or operational responsibility. Start with one host and a small
+number of credentials, verify one client call, and expand only after that works.

--- a/gumroad-bundle/README.md
+++ b/gumroad-bundle/README.md
@@ -1,58 +1,51 @@
-# Free LLM Gateway Starter Kit (Gumroad Bundle)
+# Free LLM Gateway Starter Kit
 
-This directory is the **product** sold on Gumroad. It is a self-contained
-curation layer on top of the public, open-source gateway at
-[github.com/ons96/LLM-API-Key-Proxy](https://github.com/ons96/LLM-API-Key-Proxy).
+Setup materials for a self-hosted, OpenAI-compatible gateway. This bundle does
+not include gateway source, hosting, provider accounts, API keys, uptime, or
+support.
 
-The gateway code is free and always will be. What this bundle sells is the
-convenience of a 30-minute setup path, a sanitized config template, a one-click
-deploy script, tool-integration examples, and email support.
+## Included files
 
-## Files
+| File | Purpose |
+|---|---|
+| `SETUP_GUIDE.md` | Secure installation, local testing, SSH tunnel, and HTTPS proxy guidance. |
+| `.env.starter` | Sanitized environment template. |
+| `quickstart.sh` | Idempotent Ubuntu/Debian systemd installer bound to loopback only. |
+| `GUMROAD_LISTING.md` | Unpublished product-page draft. |
+| `CHANGELOG.md` | Bundle version history. |
+| `package-release.sh` | Packages and validates the exact buyer archive. |
 
-| File | What it is |
-|------|------------|
-| `SETUP_GUIDE.md` | The main deliverable. Step-by-step guide from zero to a working free gateway. |
-| `.env.starter` | Sanitized config template with `# TODO` markers for free provider keys. |
-| `quickstart.sh` | One-click setup script for a fresh Ubuntu/Debian VPS. |
-| `GUMROAD_LISTING.md` | Copy for the Gumroad product page (title, pricing, FAQ). |
-| `CHANGELOG.md` | Version history of the bundle. |
-| `README.md` | This file. |
+## Product terms
 
-## How to package for Gumroad
+One one-time product: USD 19 for the first 10 completed purchases or the first
+14 calendar days after launch, whichever comes first, then USD 29. Set the
+actual UTC launch deadline immediately before publishing.
 
-The bundle is designed to ship as a single zip. From the repo root:
+Buyers receive published v1.x bundle updates. The purchase does not include
+hosting, provider accounts, a service-level commitment, personal support, or a
+future major version.
+
+Third-party provider, hosting, and marketplace terms, availability, quotas, and
+charges can change. Buyers must use accounts they control and review the terms
+that apply to them.
+
+## Package release
+
+From this directory, run:
 
 ```bash
-zip -r gateway-starter-kit.zip gumroad-bundle/
+bash package-release.sh
 ```
 
-Upload `gateway-starter-kit.zip` as the product file on Gumroad. Buyers unzip
-it and follow `SETUP_GUIDE.md`. The guide also tells buyers they can clone the
-public repo (which contains this `gumroad-bundle/` directory) if they prefer
-git over a zip.
+It writes a ZIP and SHA-256 file under `/tmp/free-llm-gateway-starter-kit/` by
+default, includes only the listed bundle files, and verifies the archive. Set
+`OUT_DIR` to use another local output directory.
 
-## Two tiers
+Review the generated archive, complete the platform's tax, payout, and identity
+steps, then upload it manually. Do not package the whole repository.
 
-- **Standard ($29):** guide + templates + script + 30-day email support.
-- **Bonus ($49):** adds the auto-optimizing reorder service (systemd timer that
-  re-ranks fallback chains from live telemetry every 30 minutes).
+## Source licensing
 
-To ship the bonus tier, include the reorder service setup section of
-`SETUP_GUIDE.md` (the "Enable the reorder service" subsection under
-"Customizing") and the associated scripts. The standard tier omits that section.
-
-## What this bundle does NOT include
-
-- The gateway source code (it is in the public repo; buyers clone it).
-- Any real API keys, internal VPS IPs, or private config (the starter template
-  is fully sanitized).
-- A hosting account (buyers create their own free Oracle Cloud account).
-
-## Maintenance
-
-When the underlying gateway repo changes in a way that affects setup (new
-required env var, changed virtual model names, new systemd path), bump the
-bundle version in `CHANGELOG.md` and update `SETUP_GUIDE.md` + `.env.starter`.
-Re-zip and re-upload to Gumroad. Existing buyers get the update if you enable
-Gumroad's "buyers get free updates" option.
+Gateway source is separately licensed: the proxy application is MIT and the
+rotator library is LGPL-3.0. This bundle contains setup materials only; source
+use and redistribution are governed by the repository license notices.

--- a/gumroad-bundle/SETUP_GUIDE.md
+++ b/gumroad-bundle/SETUP_GUIDE.md
@@ -1,626 +1,200 @@
 # Free LLM Gateway Starter Kit -- Setup Guide
 
-> Version 1.0.0 | Updated 2026-07-16
-> Time to complete: about 30 minutes. Everything you need is free.
+Version 1.0.0 | Updated 2026-07-16
 
----
+This guide installs a self-hosted, OpenAI-compatible gateway from the public
+source checkout. It does not provide hosting, provider accounts, credentials,
+uptime, or a guaranteed zero-cost service. Third-party availability, eligibility,
+quotas, and charges can change; review each provider and host before use.
 
-## What you're building
+## Security first
 
-You are about to set up your own **free OpenAI-compatible LLM gateway** on a
-tiny cloud server. Instead of juggling nine different provider accounts and
-hardcoding each one into your coding tools, you point your tools at **one
-URL** and the gateway does the rest:
+The installer binds the gateway to `127.0.0.1:8000` only. Do not expose TCP
+port 8000 directly. Use an SSH tunnel for personal remote access. If you need
+internet-facing access, put a separately configured HTTPS reverse proxy such as
+Caddy on ports 80/443 in front of the loopback service. Keep `PROXY_API_KEY`
+set even behind HTTPS.
 
-- It speaks the OpenAI API (`/v1/chat/completions`, `/v1/models`), so any
-  tool that accepts a custom OpenAI base URL works immediately.
-- It exposes a handful of **virtual models** -- `coding-elite`, `coding-fast`,
-  `chat-smart`, `chat-fast` -- each backed by a **fallback chain** of free
-  providers. If Groq is rate-limited, it silently tries Cerebras, then Gemini,
-  and so on. You never see the failure.
-- It runs on a 1 GB Oracle Cloud free-tier VM, costs $0/month, and stays up
-  24/7 (no sleep, unlike Render's free tier).
+Never share `.env`, provider credentials, or `PROXY_API_KEY`. Do not paste them
+into support chats, issue trackers, screenshots, or public repositories.
 
-The gateway code itself is [open source](https://github.com/ons96/LLM-API-Key-Proxy)
-and always will be. What you paid for is this curated 30-minute path, the
-pre-filled config template, the one-click setup script, and support. You are
-buying the convenience, not the code.
+## 1. Prepare a host
 
----
-
-## What you need (all free)
-
-| Item | Where to get it | Cost | Time |
-|------|-----------------|------|------|
-| Oracle Cloud account | [cloud.oracle.com](https://cloud.oracle.com) | Free tier, credit card verify only | 5 min |
-| Groq API key | [console.groq.com](https://console.groq.com/keys) | Free, generous limits | 2 min |
-| Google Gemini key | [aistudio.google.com](https://aistudio.google.com/apikey) | Free tier | 2 min |
-| Cerebras key (optional) | [cloud.cerebras.ai](https://cloud.cerebras.ai) | Free, 1M tokens/day | 2 min |
-| NVIDIA NIM key (optional) | [build.nvidia.com](https://build.nvidia.com) | Free | 2 min |
-| Your laptop's SSH key | `ssh-keygen` if you don't have one | Free | 1 min |
-
-You can get a working gateway with **just Groq + Gemini** (two keys, ~4 min).
-The others add more fallback headroom so a rate-limit on one provider never
-reaches you. Cerebras is worth the two minutes -- it is extremely fast.
-
-You do **not** need a credit card that gets charged. Oracle requires a card
-to verify identity; the Always Free tier is never billed as long as you stay
-within the free limits (which this gateway does easily on 1 GB RAM).
-
----
-
-## Step 1: Get a free VPS (Oracle Cloud Always Free) -- ~10 min
-
-We use Oracle Cloud because their "Always Free" tier includes a real
-always-on VM with more RAM than other free tiers, and it does not sleep.
-
-### 1.1 Sign up
-
-1. Go to [cloud.oracle.com](https://cloud.oracle.com) and click **Sign up**.
-2. Choose the **Home Region** closest to you (this cannot be changed later
-   without opening a support ticket).
-3. Enter a credit card for verification. **You will not be charged.** The
-   Always Free resources are explicitly excluded from billing.
-4. Wait for the account to provision (can take up to 15 minutes; you'll get
-   an email).
-
-### 1.2 Generate an SSH key pair
-
-If you already have `~/.ssh/id_ed25519.pub` or `~/.ssh/id_rsa.pub`, skip to
-1.3. Otherwise, on your laptop:
+Use an Ubuntu or Debian host where you have a normal user account with `sudo`.
+Choose a provider and plan yourself, review its current terms, and keep your SSH
+key safe. From your computer, verify you can sign in:
 
 ```bash
-ssh-keygen -t ed25519 -C "your_email@example.com"
-# Press Enter to accept the default path, set a passphrase or leave empty
+ssh user@YOUR_SERVER
 ```
 
-You need the **public** key (the contents of `id_ed25519.pub`) in the next step.
+Apply the host's normal security updates before installing software.
 
-### 1.3 Create the Always Free instance
+## 2. Get the source and bundle
 
-1. In the Oracle Cloud console, open the hamburger menu (top left) and go to
-   **Compute -> Instances**.
-2. Click **Create instance**.
-3. **Name**: `llm-gateway` (or anything you like).
-4. **Image and shape**: Click *Edit* next to Image and Shape.
-   - **Image**: Canonical **Ubuntu 22.04** (or 24.04). Click *Change image*,
-     pick "Canonical Ubuntu 22.04" under "Free tier eligible", save.
-   - **Shape**: Click *Change shape*. Under "Ampere" (ARM) select
-     **VM.Standard.A1.Flex**. Set **1 OCPU** and **6 GB RAM** -- these stay
-     free (the A1 flex shape is the generous one). If ARM shapes are
-     unavailable in your region, use **VM.Standard.E2.1.Micro** (AMD, 1 GB)
-     -- it also works, just tighter. Save.
-5. **Add SSH keys**: choose **"Save private key" and "Save public key"** OR
-   paste your existing public key from step 1.2 into the box. This is how you
-   will log in. **Do not skip this** -- you cannot SSH in without it.
-6. Click **Create**. The instance provisions in 1-3 minutes.
-
-### 1.4 Find your public IP
-
-On the instance's detail page, copy the **Public IP Address** (looks like
-`129.150.x.x`). Save it -- you'll use it constantly.
-
-### 1.5 Open port 8000 (security list)
-
-The gateway listens on port 8000. Oracle blocks it by default. You need to
-allow your own traffic.
-
-1. On the instance detail page, scroll to **Resources -> Subnet** and click
-   the subnet link.
-2. Click the **Security List** (usually `Default Security List for ...`).
-3. Click **Add Ingress Rules**:
-   - **Source CIDR**: your home/office IP followed by `/32`, e.g.
-     `203.0.113.42/32`. To find your current public IP, visit
-     [ifconfig.me](https://ifconfig.me) from the same network.
-     - For maximum security, lock it to your IP. If your IP changes often,
-       use a VPN/Tailscale (see "Customizing" later). **Do not use
-       `0.0.0.0/0`** unless you are sure -- it exposes your gateway to the
-       whole internet.
-   - **IP Protocol**: TCP
-   - **Destination Port Range**: `8000`
-4. Click **Add Ingress Rules**.
-
-### 1.6 SSH in and update
+The gateway source is public. Clone it on the host:
 
 ```bash
-ssh ubuntu@YOUR_PUBLIC_IP
-# Accept the host key fingerprint on first connect
-sudo apt update && sudo apt upgrade -y
-```
-
-If the `ubuntu` user doesn't work, try `opc`. Oracle Ubuntu images use
-`ubuntu` by default.
-
-You now have a server. Move on to getting your LLM keys.
-
----
-
-## Step 2: Get free LLM provider keys -- ~5 min
-
-Get at least **Groq** and **Gemini**. The others are bonus fallback layers.
-
-| Provider | Signup URL | What to copy | Free limit (approx) | Notes |
-|----------|-----------|--------------|---------------------|-------|
-| Groq | [console.groq.com/keys](https://console.groq.com/keys) | `gsk_...` key | ~30 req/min, generous daily | Fastest free coding models. Start here. |
-| Gemini | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | `AIza...` key | 15 req/min free tier | Google models, good quality |
-| Cerebras | [cloud.cerebras.ai](https://cloud.cerebras.ai) | `csk-...` key | 1M tokens/day free | Insanely fast inference |
-| NVIDIA NIM | [build.nvidia.com](https://build.nvidia.com) | `nvapi-...` key | 40 req/min, 1000 credits | Many open models |
-| Mistral | [console.mistral.ai](https://console.mistral.ai) | key from API Keys page | Free tier with La Plateforme | Codestral good for code |
-| OpenRouter | [openrouter.ai/keys](https://openrouter.ai/keys) | `sk-or-...` key | Free models, paid ones too | Aggregator; pick `:free` models |
-| HuggingFace | [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) | `hf_...` token | Rate-limited free inference | Optional, queue-based |
-
-**Tips:**
-- On each site, sign up, find the "API Keys" or "Tokens" page, and click
-  "Create new key". Copy the value immediately -- some sites hide it after.
-- Store the keys in a text file on your laptop for now. We'll paste them into
-  the config in Step 3.
-- All of these have **free tiers that do not require a credit card** (except
-  OpenRouter, which is free for the `:free` models and lets you add credits
-  later if you want paid models -- entirely optional).
-
-You do not need all of them. Two is enough to have automatic fallback. Five
-gives you a robust setup that rarely shows you an error.
-
----
-
-## Step 3: Deploy the gateway -- ~10 min
-
-Run this on your VPS (you are SSH'd in from Step 1.6).
-
-### 3.1 Clone the repo
-
-```bash
-cd ~
 git clone https://github.com/ons96/LLM-API-Key-Proxy.git
 cd LLM-API-Key-Proxy
 ```
 
-> If you purchased this bundle, the `gumroad-bundle/` directory is part of
-> the public repo. If you cloned without it (older checkout), you can
-> instead clone the bundle separately or copy the files from your download.
+If the purchased bundle is newer than the copy in the checkout, replace only
+the `gumroad-bundle/` directory with the downloaded one. Do not overwrite your
+existing `.env`.
 
-### 3.2 Copy the starter config
+Gateway source licensing is separate from this bundle: the proxy application is
+MIT and the rotator library is LGPL-3.0. Review the root license notices before
+redistributing source.
+
+## 3. Configure credentials
+
+Create a private environment file:
 
 ```bash
 cp gumroad-bundle/.env.starter .env
-chmod 600 .env   # only your user can read it -- good hygiene
+chmod 600 .env
+openssl rand -hex 32
 ```
 
-### 3.3 Fill in your free keys
+Paste the generated value into `PROXY_API_KEY` in `.env`. It protects your
+gateway from unauthenticated requests. The installer refuses an empty,
+placeholder, or short proxy key.
 
-Open `.env` in an editor (`nano .env` is easiest on a fresh VPS). Find every
-line that says `# TODO: fill in your free key from <URL>` and paste your key.
-At minimum, fill in:
+Add only credentials for provider accounts you created and control. Check
+`config/router_config.yaml` for the corresponding credential names and current
+routing policy. A setting in `.env` does not override router policy by itself.
 
-```
-GROQ_API_KEY_1="gsk_your_real_groq_key"
-GEMINI_API_KEY_1="AIza_your_real_gemini_key"
-```
+Before continuing, confirm that `.env` is not tracked:
 
-Also set a **proxy password** -- this is the key your coding tools will use to
-talk to your gateway. Make up any strong string:
-
-```
-PROXY_API_KEY="make-up-a-long-random-string-here"
+```bash
+git status --short .env
 ```
 
-Save and exit. Leave the optional providers (`CEREBRAS_API_KEY_1`, etc.) blank
-for now; you can add them later.
+It should produce no output. If it appears, stop and fix `.gitignore` before
+continuing.
 
-### 3.4 Run the one-click setup script
+## 4. Install the loopback service
+
+Run as your normal user; the script asks for `sudo` only when installing the
+systemd unit:
 
 ```bash
 bash gumroad-bundle/quickstart.sh
 ```
 
-The script does the rest:
+The script installs `uv` and Python if needed, creates a virtual environment,
+installs requirements, creates `llm-gateway.service`, starts it, checks
+`/health`, verifies the listener is loopback-only, and makes an authenticated
+`/v1/models` request.
 
-1. Installs **uv** (a fast Python package manager) and Python 3.12 if needed.
-2. Creates a virtualenv and installs the gateway dependencies.
-3. Writes a **systemd service** so the gateway starts on boot and restarts on
-   crash, capped at **400 MB RAM** so your 1 GB VPS never runs out.
-4. Starts the service.
-5. Runs a smoke test (`curl /v1/models`).
-6. Prints your gateway URL and next steps.
-
-Watch the output. When it finishes you'll see something like:
-
-```
-============================================================
-  Gateway is live: http://129.150.x.x:8000/v1
-  Proxy password: the PROXY_API_KEY you set in .env
-  Next: point your coding tools here (see SETUP_GUIDE.md Step 5)
-============================================================
-```
-
-If the smoke test failed, jump to **Troubleshooting** below -- the common
-causes are listed and each has a one-line fix.
-
----
-
-## Step 4: Test it -- ~2 min
-
-Still on the VPS (or from your laptop if port 8000 is open to your IP), run:
-
-### 4.1 List the virtual models
+Inspect its state and logs:
 
 ```bash
-curl http://localhost:8000/v1/models \
+sudo systemctl status llm-gateway
+sudo journalctl -u llm-gateway -n 50 --no-pager
+```
+
+## 5. Test locally
+
+On the server, use the proxy key from `.env`:
+
+```bash
+curl http://127.0.0.1:8000/health
+curl http://127.0.0.1:8000/v1/models \
   -H "Authorization: Bearer YOUR_PROXY_API_KEY"
 ```
 
-You should get JSON with the virtual models -- `coding-elite`, `coding-fast`,
-`chat-smart`, `chat-fast`, and more -- alongside the raw provider models.
+An empty model result can mean no usable provider credentials are configured.
+Check the service logs and the router configuration before adding more keys.
 
-### 4.2 Send a chat completion through a virtual model
+## 6. Use an SSH tunnel first
 
-```bash
-curl -X POST http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer YOUR_PROXY_API_KEY" \
-  -d '{
-    "model": "coding-elite",
-    "messages": [{"role": "user", "content": "Write a Python function that reverses a string."}],
-    "max_tokens": 200
-  }'
-```
-
-You should get a normal OpenAI-style JSON response with the assistant's
-answer. If you do, the fallback chain worked -- you didn't have to know or
-care which provider served it.
-
-### 4.3 Check health
+From your own computer, leave this command running:
 
 ```bash
-curl http://localhost:8000/health
+ssh -N -L 8000:127.0.0.1:8000 user@YOUR_SERVER
 ```
 
-Returns a small JSON status. If the gateway is running, this always responds.
-
-### 4.4 Watch it fall back (optional, but satisfying)
-
-To see fallback in action, temporarily set a garbage Groq key in `.env`
-(`GROQ_API_KEY_1="invalid"`), restart the service
-(`sudo systemctl restart llm-gateway`), and re-run the chat completion. It
-will still succeed -- just served by the next provider in the chain. Restore
-your real key afterward.
-
----
-
-## Step 5: Point your tools at it -- ~3 min
-
-Your gateway is an OpenAI-compatible endpoint. Any tool that lets you set a
-custom OpenAI base URL works. Use these values:
+Your local client can now use:
 
 | Setting | Value |
-|---------|-------|
-| Base URL | `http://YOUR_VPS_IP:8000/v1` |
-| API key | the `PROXY_API_KEY` you set in `.env` |
-| Model | `coding-elite` (or `coding-fast`, `chat-smart`, `chat-fast`) |
+|---|---|
+| Base URL | `http://127.0.0.1:8000/v1` |
+| API key | Your `PROXY_API_KEY` |
+| Model | A model returned by `/v1/models` |
 
-### OpenCode
+For an OpenAI-compatible client, use the local base URL above and the proxy key.
+This avoids exposing the gateway while you validate one client end to end.
 
-In your OpenCode config (`~/.config/opencode/opencode.json` or project
-`.opencode/opencode.json`), add a provider:
+## 7. Optional public HTTPS access
 
-```json
-{
-  "provider": {
-    "my-gateway": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "My Free Gateway",
-      "options": {
-        "baseURL": "http://YOUR_VPS_IP:8000/v1",
-        "apiKey": "YOUR_PROXY_API_KEY"
-      },
-      "models": {
-        "coding-elite": { "name": "coding-elite" },
-        "coding-fast": { "name": "coding-fast" },
-        "chat-smart": { "name": "chat-smart" },
-        "chat-fast": { "name": "chat-fast" }
-      }
-    }
-  }
+Do this only after local and SSH-tunnel testing work. You need a domain whose
+DNS points to the server and firewall rules for HTTPS only. Do not open TCP/8000.
+
+Install Caddy using its official installation instructions, then use a minimal
+configuration like:
+
+```caddy
+gateway.example.com {
+    reverse_proxy 127.0.0.1:8000
 }
 ```
 
-Then pick `coding-elite` from the model dropdown.
-
-### Cursor
-
-1. Open **Settings -> Models**.
-2. Add a custom OpenAI-compatible provider:
-   - **Base URL**: `http://YOUR_VPS_IP:8000/v1`
-   - **API Key**: `YOUR_PROXY_API_KEY`
-   - **Model**: `coding-elite`
-3. Verify the connection.
-
-### continue.dev (VS Code)
-
-Edit `~/.continue/config.json`:
-
-```json
-{
-  "models": [{
-    "title": "My Free Gateway",
-    "provider": "openai",
-    "model": "coding-elite",
-    "apiBase": "http://YOUR_VPS_IP:8000/v1",
-    "apiKey": "YOUR_PROXY_API_KEY"
-  }]
-}
-```
-
-### LangChain (Python)
-
-```python
-from langchain_openai import ChatOpenAI
-
-llm = ChatOpenAI(
-    base_url="http://YOUR_VPS_IP:8000/v1",
-    api_key="YOUR_PROXY_API_KEY",
-    model="coding-elite",
-)
-print(llm.invoke("Write a Python function that reverses a string.").content)
-```
-
-### Anything else that speaks OpenAI
-
-Set `OPENAI_BASE_URL=http://YOUR_VPS_IP:8000/v1` and
-`OPENAI_API_KEY=YOUR_PROXY_API_KEY` as environment variables. Most tools pick
-those up automatically.
-
-> **About HTTP vs HTTPS**: This guide uses plain `http://`. For local-network
-> or personal use that's fine. If you expose the gateway to the internet,
-> put it behind a reverse proxy (Caddy/Nginx) with TLS. See "Customizing".
-
----
+Open only ports 80 and 443 as required for the HTTPS proxy. Test the public
+endpoint with `https://gateway.example.com/v1/models` and the proxy key. The
+gateway process must still show `127.0.0.1:8000` as its listener.
 
 ## Troubleshooting
 
-### "Connection refused" / can't reach port 8000
+### The service fails to start
 
-- Did you open port 8000 in the Oracle **security list** (Step 1.5)? That's
-  the #1 cause. The VM firewall and the Oracle security list are separate --
-  you need the security list rule.
-- Is the service running? `sudo systemctl status llm-gateway`. If it says
-  `failed`, check logs: `sudo journalctl -u llm-gateway -n 50 --no-pager`.
-- Are you testing from an IP you allowed? If you locked the security list to
-  your home IP and you're on a different network, it will time out.
-
-### "401 Unauthorized" from the gateway
-
-- The `PROXY_API_KEY` in your `.env` must match the `Authorization: Bearer`
-  value your client sends. Re-check for trailing quotes or whitespace.
-- If you set `PROXY_API_KEY` to empty in `.env.starter`, the gateway runs
-  **unauthenticated**. That's fine for testing but don't leave it open to the
-  internet.
-
-### Provider returns "invalid api key" / 401 from upstream
-
-- That specific provider's key is wrong or expired. The gateway **falls back
-  to the next provider automatically**, so your request still succeeds -- but
-  you'll see warnings in the logs. Fix the bad key in `.env` and restart:
-  `sudo systemctl restart llm-gateway`.
-
-### Provider rate-limited (429)
-
-- This is exactly what the fallback chain is for. You usually won't notice.
-- If you hit it often, add more providers (Cerebras, NVIDIA) so the load
-  spreads. Each free key adds headroom.
-
-### Gateway crashes / OOM on 1 GB RAM
-
-- The systemd unit is capped at `MemoryMax=400M`. If the VPS only has 1 GB,
-  that's the right setting -- do not raise it.
-- If you picked the ARM shape with 6 GB, you can raise it to `800M` or remove
-  the cap.
-- Symptom: `sudo journalctl -u llm-gateway` shows `Killed` or
-  `Out of memory`. Fix: `sudo systemctl daemon-reload && sudo systemctl
-  restart llm-gateway`. Ensure no other memory-hungry service is running.
-
-### Models list is empty or only shows a few
-
-- You have no working provider keys. Confirm Groq/Gemini keys are valid. Run
-  `curl http://localhost:8000/v1/models` again after fixing.
-- A provider may be marked disabled in `config/router_config.yaml`. The
-  starter `.env` enables the free ones; check the file if you customized it.
-
-### "Model not found" when calling a virtual model
-
-- Use the exact virtual model name: `coding-elite`, not `coding_elite` or
-  `CodingElite`. Check `/v1/models` for the exact strings.
-- The chain may have zero available providers if all your keys are invalid.
-  See the 401 note above.
-
-### Changes to `.env` don't take effect
-
-- The systemd service reads `.env` at start. After editing: `sudo systemctl
-  restart llm-gateway`.
-
----
-
-## What you get
-
-### Virtual models (the main interface)
-
-These are the names you put in your tools. Each is backed by a fallback chain
-that tries free providers in priority order.
-
-| Virtual model | Best for | Behavior |
-|---------------|----------|----------|
-| `coding-elite` | Agentic coding, complex generation | Highest-quality free coding models first, then broader fallbacks |
-| `coding-fast` | Quick edits, completions | Speed-prioritized chain (low latency) |
-| `chat-smart` | Reasoning, analysis, research | Intelligence-weighted chain |
-| `chat-fast` | Quick Q&A, low-latency chat | TPS-ranked chain |
-| `auto` | Let the gateway decide | Semantic intent routing to the right chain |
-
-The full list with current chains lives in `config/virtual_models.yaml`.
-Chains are long (dozens of candidates deep) so a single rate-limit never
-reaches you.
-
-### Automatic fallback
-
-When a request to priority-1 provider fails (rate limit, timeout, error), the
-router immediately tries priority-2, then 3, and so on. If a provider is on
-cooldown from a recent 429, it is skipped entirely until its cooldown
-expires. You see one successful response; the retries are invisible.
-
-### Telemetry
-
-The gateway logs every request to an SQLite database
-(`/dev/shm/telemetry.db` -- in-memory, wiped on reboot by default). Tracked:
-time-to-first-token, tokens-per-second, success/failure per provider, token
-counts, cost estimates. Use it to see which providers actually serve you:
+Read the recent journal, then validate the environment-file path, Python
+dependencies, and port availability:
 
 ```bash
-sqlite3 /dev/shm/telemetry.db \
-  "SELECT provider, COUNT(*) as calls, ROUND(AVG(tps),1) as avg_tps
-   FROM llm_events WHERE success=1 GROUP BY provider ORDER BY calls DESC LIMIT 10;"
+sudo journalctl -u llm-gateway -n 50 --no-pager
+sudo ss -ltnp 'sport = :8000'
 ```
 
-### The reorder service (bonus tier)
+### I receive 401
 
-If you bought the bundle with the reorder-chains bonus, you also get a
-systemd timer that runs every 30 minutes and **re-ranks your fallback chains
-based on live speed and quality data** from telemetry. Over time, your
-`coding-elite` chain self-optimizes toward whichever free providers are
-actually fastest for you right now. Setup is in `SETUP_GUIDE.md` ->
-"Customizing -> Enable the reorder service". If you have the standard tier,
-you can enable it manually using the scripts in `scripts/` -- see that
-section.
-
----
-
-## Customizing
-
-### Add or remove a provider
-
-1. Get the provider's free key (Step 2 table).
-2. Add it to `.env`, e.g. `CEREBRAS_API_KEY_1="csk_..."`.
-3. Confirm the provider is `enabled: true` in `config/router_config.yaml`.
-   The free providers are enabled by default in the starter config.
-4. `sudo systemctl restart llm-gateway`.
-
-To remove a provider, set `enabled: false` in `router_config.yaml` (or just
-blank its key in `.env`).
-
-### Tune a fallback chain
-
-Open `config/virtual_models.yaml`. Each virtual model has a `fallback_chain`
-list ordered by `priority` (1 = tried first). Reorder, add, or remove
-entries. Restart the service. This is a normal YAML edit -- no code changes.
-
-> Note: if you enable the reorder service (below), it rewrites this file
-> every 30 min from telemetry data. Hand-edits will be overwritten. To keep
-> manual control, either don't enable the timer, or edit and then stop the
-> timer (`sudo systemctl stop reorder-chains.timer`).
-
-### Change the virtual model definitions
-
-Same file: `config/virtual_models.yaml`. You can add a new virtual model by
-copying an existing block and changing the name and chain. It will appear in
-`/v1/models` automatically after restart.
-
-### Enable the reorder service (auto-optimize chains)
-
-The reorder service reads your telemetry and rewrites the fallback chains to
-favor your fastest, most-reliable providers. To enable:
+Use exactly `Authorization: Bearer YOUR_PROXY_API_KEY`. Restart the service
+after changing `.env`:
 
 ```bash
-cd ~/LLM-API-Key-Proxy
-sudo cp scripts/reorder-chains.service /etc/systemd/system/
-sudo cp scripts/reorder-chains.timer /etc/systemd/system/
-# Edit the .service file: replace /home/ubuntu paths with your install path
-# if different, and set LLM_BENCHMARK_DB / LLM_PROVIDERS_DB if you have them
-# (optional -- without them it falls back to telemetry-only ranking).
-sudo systemctl daemon-reload
-sudo systemctl enable --now reorder-chains.timer
+sudo systemctl restart llm-gateway
 ```
 
-It runs every 30 minutes. Check status with
-`systemctl status reorder-chains.service`.
+### I cannot connect from another device
 
-### Secure it with HTTPS
+That is expected before you create an SSH tunnel or HTTPS reverse proxy. The
+installer intentionally keeps the gateway on loopback.
 
-For internet-facing use, put the gateway behind Caddy (automatic Let's
-Encrypt):
+### A provider request fails or is rate limited
 
-```bash
-sudo apt install -y caddy
-# Edit /etc/caddy/caddyfile:
-#   your-domain.com {
-#     reverse_proxy 127.0.0.1:8000
-#   }
-sudo systemctl restart caddy
-```
+Check the journal and confirm the credential and router configuration for that
+provider. Upstream failures, limits, and models vary; do not assume any fallback
+will be available.
 
-Point your domain's A record at the VPS IP first. Now your base URL becomes
-`https://your-domain.com/v1`.
+## Updating
 
-### Lock access down with Tailscale (recommended)
-
-Instead of opening port 8000 to a specific IP (which breaks when your IP
-changes), install [Tailscale](https://tailscale.com) on the VPS and your
-devices. The gateway then only needs to listen on the Tailscale interface,
-and you connect via a stable private IP. Free for personal use.
-
-### Back up your config
-
-Your `.env` and any custom `config/*.yaml` edits are the only things unique
-to you. Back them up somewhere off the VPS:
-
-```bash
-# On your laptop
-scp ubuntu@YOUR_VPS_IP:~/LLM-API-Key-Proxy/.env ./gateway-env-backup
-```
-
----
-
-## Updating the gateway
-
-The repo gets improvements over time. To update:
+Read release notes before updating a running gateway. Back up `.env` privately,
+then update the source and dependencies:
 
 ```bash
 cd ~/LLM-API-Key-Proxy
 git pull
 source venv/bin/activate
-uv pip install -r requirements.txt   # or: pip install -r requirements.txt
+uv pip install -r requirements.txt
 sudo systemctl restart llm-gateway
 ```
 
-Your `.env` and config edits are preserved (they're not tracked by git). If a
-config schema changed, check `CHANGELOG.md` in this bundle for migration
-notes.
+Re-run the local health and authenticated model-list checks after every update.
 
----
+## Bundle scope
 
-## Support
-
-Purchased the bundle with support? Email the address in your Gumroad receipt
-with:
-- What you expected, what happened, and the exact error.
-- Output of `sudo journalctl -u llm-gateway -n 50 --no-pager`.
-- Your `.env` with the key values redacted (replace each with `XXXX`).
-
-We respond within 2 business days, 30 days from purchase.
-
----
-
-## Honest expectations
-
-- **Free tiers have rate limits.** Groq ~30 req/min, Gemini ~15 req/min,
-  Cerebras 1M tokens/day. The gateway's job is to spread load across them so
-  you rarely hit a wall -- but it is not "unlimited free LLMs forever."
-  Heavy agentic-coding sessions may occasionally wait for a cooldown.
-- **Quality varies by provider.** `coding-elite` prefers the best free coding
-  models available; it is not a paid Claude/GPT-tier experience, though some
-  free models (GLM-5.2, Gemini 3 Pro, Qwen3) are genuinely strong.
-- **The VPS is yours to maintain.** Oracle occasionally restarts instances;
-  systemd brings the gateway back automatically. Apply OS security updates
-  now and then (`sudo apt update && sudo apt upgrade -y`).
-- **You can add paid providers later.** Drop an OpenAI or Anthropic key in
-  `.env` and they join the fallback chains. The free-first ordering keeps
-  your bill at zero unless you explicitly change it.
-
-You now have a personal, free, always-on LLM gateway. Enjoy.
+Buyers receive published v1.x updates to these setup materials. This purchase
+does not include personal support, hosting, provider accounts, credentials,
+service-level commitments, or future-major-version access. Use the checkout
+platform's published refund process and policy.

--- a/gumroad-bundle/package-release.sh
+++ b/gumroad-bundle/package-release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Create only the buyer-facing bundle; never archive the gateway source checkout.
+set -euo pipefail
+
+VERSION="1.0.0"
+OUT_DIR="${OUT_DIR:-/tmp/free-llm-gateway-starter-kit}"
+ARCHIVE="${OUT_DIR}/free-llm-gateway-starter-kit-v${VERSION}.zip"
+FILES=(CHANGELOG.md GUMROAD_LISTING.md README.md SETUP_GUIDE.md .env.starter quickstart.sh package-release.sh)
+BUNDLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+die() { printf '[package] ERROR: %s\n' "$*" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || die "python3 is required."
+
+cd "${BUNDLE_DIR}"
+
+for file in "${FILES[@]}"; do
+    [ -f "${file}" ] || die "Missing ${file}; run this from gumroad-bundle/."
+done
+
+python3 - "${ARCHIVE}" "${FILES[@]}" <<'PY'
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+from sys import argv
+from zipfile import ZIP_DEFLATED, ZipFile
+
+archive = Path(argv[1])
+files = [Path(value) for value in argv[2:]]
+entries = [f"gumroad-bundle/{file.name}" for file in files]
+
+archive.parent.mkdir(parents=True, exist_ok=True)
+with ZipFile(archive, "w", compression=ZIP_DEFLATED, compresslevel=9) as bundle:
+    for file, entry in zip(files, entries, strict=True):
+        bundle.write(file, entry)
+
+with ZipFile(archive) as bundle:
+    missing = set(entries) - set(bundle.namelist())
+    if missing:
+        raise SystemExit(f"[package] ERROR: archive omitted {sorted(missing)!r}")
+    bad_file = bundle.testzip()
+    if bad_file:
+        raise SystemExit(f"[package] ERROR: corrupt archive entry {bad_file}")
+
+digest = sha256(archive.read_bytes()).hexdigest()
+checksum = archive.with_suffix(archive.suffix + ".sha256")
+checksum.write_text(f"{digest}  {archive.name}\n", encoding="ascii")
+print(f"[package] verified {archive}")
+print(f"[package] sha256 {checksum}")
+PY

--- a/gumroad-bundle/quickstart.sh
+++ b/gumroad-bundle/quickstart.sh
@@ -1,233 +1,148 @@
 #!/usr/bin/env bash
-# =============================================================================
-# Free LLM Gateway -- one-click setup script
-# Bundle: gumroad-bundle/quickstart.sh
+# Free LLM Gateway -- loopback-only installer
 #
-# Run this ON your fresh Oracle Cloud (or any Ubuntu/Debian) VPS, as a normal
-# user with sudo. It:
-#   1. Installs uv + Python 3.12 if missing
-#   2. Creates a venv and installs gateway deps
-#   3. Writes a systemd service (MemoryMax=400M, auto-restart, port 8000)
-#   4. Starts the service
-#   5. Runs a smoke test (curl /v1/models)
-#   6. Prints the gateway URL and next steps
-#
-# Idempotent: safe to re-run. Does not overwrite an existing .env.
-#
-# Usage:  bash gumroad-bundle/quickstart.sh
-# =============================================================================
+# Run from a source checkout with this bundle at gumroad-bundle/. The service
+# binds only to 127.0.0.1. It never opens a firewall or public listener.
 set -euo pipefail
 
-# ---- config -----------------------------------------------------------------
 REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 SERVICE_NAME="llm-gateway"
 SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 PORT="${GATEWAY_PORT:-8000}"
-HOST="0.0.0.0"
-LOG_FILE="/var/log/${SERVICE_NAME}.log"
+HOST="127.0.0.1"
 VENV_DIR="${REPO_DIR}/venv"
 MEMORY_MAX_MB="${GATEWAY_MEMORY_MAX_MB:-400}"
+ENV_FILE="${REPO_DIR}/.env"
 
-# ---- helpers ----------------------------------------------------------------
-log()  { printf '[setup] %s\n' "$*"; }
-err()  { printf '[setup] ERROR: %s\n' "$*" >&2; }
-die()  { err "$*"; exit 1; }
+log() { printf '[setup] %s\n' "$*"; }
+die() { printf '[setup] ERROR: %s\n' "$*" >&2; exit 1; }
 step() { printf '\n=== %s ===\n' "$*"; }
 
-# ---- preflight --------------------------------------------------------------
-step "Preflight checks"
-[ -d "${REPO_DIR}/src/proxy_app" ] || die "Repo not found at ${REPO_DIR}. Run from inside the cloned LLM-API-Key-Proxy directory."
-[ -f "${REPO_DIR}/requirements.txt" ] || die "requirements.txt missing. Is this the right repo?"
+env_value() {
+    local key="$1" line value=""
+    while IFS= read -r line || [ -n "${line}" ]; do
+        if [[ "${line}" == "${key}="* ]]; then
+            value="${line#*=}"
+        fi
+    done < "${ENV_FILE}"
+    value="${value#\"}"
+    value="${value%\"}"
+    printf '%s' "${value}"
+}
 
-# Determine the service user. On Oracle Ubuntu images it's 'ubuntu'; on
-# others it may be the current user. We use SUDO_USER if invoked via sudo,
-# otherwise the current user.
+step "Preflight"
+[ -d "${REPO_DIR}/src/proxy_app" ] || die "Run from an LLM-API-Key-Proxy source checkout."
+[ -f "${REPO_DIR}/requirements.txt" ] || die "requirements.txt is missing."
+[[ "${PORT}" =~ ^[0-9]+$ ]] && [ "${PORT}" -gt 0 ] && [ "${PORT}" -lt 65536 ] \
+    || die "GATEWAY_PORT must be an integer from 1 through 65535."
+
 if [ -n "${SUDO_USER:-}" ] && [ "${SUDO_USER}" != "root" ]; then
     RUN_USER="${SUDO_USER}"
 else
     RUN_USER="$(id -un)"
 fi
-[ "${RUN_USER}" = "root" ] && die "Don't run this as root directly. Run as a normal user (the script will sudo when needed)."
+[ "${RUN_USER}" != "root" ] || die "Run as a normal user; the script uses sudo when needed."
 RUN_HOME="$(getent passwd "${RUN_USER}" | cut -d: -f6)"
-log "Repo:      ${REPO_DIR}"
-log "Service:   ${SERVICE_NAME} (port ${PORT}, user ${RUN_USER})"
-log "Memory cap: ${MEMORY_MAX_MB} MB"
+sudo -v
 
-# Require sudo access for systemd install
-if ! sudo -n true 2>/dev/null && [ ! -w /etc/systemd/system ]; then
-    die "This script needs sudo to install a systemd service. Re-run with: sudo -E bash gumroad-bundle/quickstart.sh  (or just provide your password when prompted)."
+step "Check configuration"
+if [ ! -f "${ENV_FILE}" ]; then
+    [ -f "${REPO_DIR}/gumroad-bundle/.env.starter" ] || die "Missing .env and starter template."
+    cp "${REPO_DIR}/gumroad-bundle/.env.starter" "${ENV_FILE}"
+    chmod 600 "${ENV_FILE}"
+    die "Created ${ENV_FILE}. Generate a key with: openssl rand -hex 32; set PROXY_API_KEY, add provider credentials, then rerun."
 fi
+chmod 600 "${ENV_FILE}"
+PROXY_KEY="$(env_value PROXY_API_KEY)"
+case "${PROXY_KEY}" in
+    ''|change-this*|YOUR_*|*TODO*) die "Set PROXY_API_KEY to a generated, non-placeholder value before starting." ;;
+esac
+[ "${#PROXY_KEY}" -ge 32 ] || die "PROXY_API_KEY must be at least 32 characters. Generate one with: openssl rand -hex 32"
 
-# ---- .env check -------------------------------------------------------------
-step "Check .env"
-if [ ! -f "${REPO_DIR}/.env" ]; then
-    if [ -f "${REPO_DIR}/gumroad-bundle/.env.starter" ]; then
-        log "No .env found. Copying starter template..."
-        cp "${REPO_DIR}/gumroad-bundle/.env.starter" "${REPO_DIR}/.env"
-        chmod 600 "${REPO_DIR}/.env"
-        log "Copied. Now edit it and fill in your free keys:"
-        log "  nano ${REPO_DIR}/.env"
-        log "Then re-run this script. Aborting so you can fill in keys first."
-        exit 0
-    else
-        die "No .env and no gumroad-bundle/.env.starter found. Create .env manually (see SETUP_GUIDE.md)."
-    fi
-fi
-
-# Warn if .env still has TODO placeholders for the two essential providers
-if grep -qE 'GROQ_API_KEY_1="(# TODO|YOUR_)' "${REPO_DIR}/.env" 2>/dev/null \
-   && grep -qE 'GEMINI_API_KEY_1="(# TODO|YOUR_)' "${REPO_DIR}/.env" 2>/dev/null; then
-    log "WARNING: GROQ_API_KEY_1 and GEMINI_API_KEY_1 still look like placeholders."
-    log "The gateway will start but may have no working providers. Edit ${REPO_DIR}/.env"
-    log "and fill in at least one real key. Continuing anyway (you can restart later)..."
-fi
-
-# ---- install uv + python ----------------------------------------------------
 step "Install uv and Python"
 if ! command -v uv >/dev/null 2>&1; then
-    log "Installing uv (fast Python package manager)..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
     # shellcheck disable=SC1091
     source "${RUN_HOME}/.local/bin/env" 2>/dev/null || source "${RUN_HOME}/.cargo/env" 2>/dev/null || true
     export PATH="${RUN_HOME}/.local/bin:${PATH}"
 fi
-if ! command -v uv >/dev/null 2>&1; then
-    die "uv install failed. Install manually: https://docs.astral.sh/uv/"
-fi
-log "uv: $(uv --version)"
+command -v uv >/dev/null 2>&1 || die "uv installation failed; install it manually and rerun."
+uv python find 3.12 >/dev/null 2>&1 || uv python install 3.12
 
-# Ensure python 3.12 via uv (does not touch system python)
-if ! uv python find 3.12 >/dev/null 2>&1; then
-    log "Installing Python 3.12 via uv..."
-    uv python install 3.12
-fi
-
-# ---- venv + deps ------------------------------------------------------------
-step "Create venv and install dependencies"
+step "Install dependencies"
 cd "${REPO_DIR}"
-if [ ! -d "${VENV_DIR}" ]; then
-    log "Creating venv at ${VENV_DIR}..."
-    uv venv "${VENV_DIR}" --python 3.12
-fi
+[ -d "${VENV_DIR}" ] || uv venv "${VENV_DIR}" --python 3.12
 # shellcheck disable=SC1091
 source "${VENV_DIR}/bin/activate"
-log "Installing requirements (this takes a few minutes on first run)..."
 uv pip install -r requirements.txt
 
-# ---- systemd service --------------------------------------------------------
-step "Install systemd service"
-# ponytail: hardcoded user/home paths because systemd does not expand shell
-# vars in ExecStart reliably; we template them in below.
+step "Install loopback-only service"
 cat > "/tmp/${SERVICE_NAME}.service" <<SERVICEEOF
 [Unit]
-Description=LLM API Gateway Proxy (free multi-provider)
-After=network.target
+Description=LLM API Gateway Proxy
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
 User=${RUN_USER}
 WorkingDirectory=${REPO_DIR}
-EnvironmentFile=${REPO_DIR}/.env
+EnvironmentFile=${ENV_FILE}
 ExecStart=${VENV_DIR}/bin/python src/proxy_app/main.py --host ${HOST} --port ${PORT}
 Restart=on-failure
 RestartSec=10
-StandardOutput=append:${LOG_FILE}
-StandardError=append:${LOG_FILE}
-# Memory cap: keeps the gateway from OOMing a 1 GB VPS. Raise to 800M on the
-# 6 GB ARM shape if you have headroom.
+NoNewPrivileges=true
 MemoryMax=${MEMORY_MAX_MB}M
 
 [Install]
 WantedBy=multi-user.target
 SERVICEEOF
-
-sudo cp "/tmp/${SERVICE_NAME}.service" "${SERVICE_FILE}"
-sudo chown root:root "${SERVICE_FILE}"
-sudo chmod 644 "${SERVICE_FILE}"
+sudo install -o root -g root -m 0644 "/tmp/${SERVICE_NAME}.service" "${SERVICE_FILE}"
 rm -f "/tmp/${SERVICE_NAME}.service"
-
-# Make sure the log file is writable by the service user
-sudo touch "${LOG_FILE}"
-sudo chown "${RUN_USER}":"$(id -gn "${RUN_USER}")" "${LOG_FILE}"
-
 sudo systemctl daemon-reload
 sudo systemctl enable "${SERVICE_NAME}"
-
-# ---- start / restart --------------------------------------------------------
-step "Start the gateway"
 sudo systemctl restart "${SERVICE_NAME}"
 
-# ---- wait for health --------------------------------------------------------
-step "Wait for health"
+step "Verify loopback service"
 HEALTH_OK=false
 for i in $(seq 1 12); do
     sleep 3
-    if curl -sf --max-time 5 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/health" >/dev/null; then
         HEALTH_OK=true
-        log "Health check passed (attempt ${i})."
         break
     fi
-    log "Waiting for gateway... (attempt ${i}/12)"
 done
-
-if [ "${HEALTH_OK}" != "true" ]; then
-    err "Gateway did not become healthy in time. Recent logs:"
+[ "${HEALTH_OK}" = true ] || {
     sudo journalctl -u "${SERVICE_NAME}" -n 30 --no-pager || true
-    die "See SETUP_GUIDE.md -> Troubleshooting. Common causes: bad provider key (still starts, check /v1/models), port in use, OOM (lower MemoryMax)."
-fi
+    die "Gateway did not become healthy."
+}
+LISTENERS="$(sudo ss -ltnH "sport = :${PORT}" || true)"
+printf '%s\n' "${LISTENERS}" | grep -Fq "127.0.0.1:${PORT}" || die "Gateway is not listening on loopback only. Check the service definition."
+case "${LISTENERS}" in
+    *"0.0.0.0:${PORT}"*|*"[::]:${PORT}"*) die "Gateway has a non-loopback listener. Check the service definition." ;;
+esac
 
-# ---- smoke test -------------------------------------------------------------
-step "Smoke test: list models"
-PROXY_KEY="$(grep -E '^PROXY_API_KEY=' "${REPO_DIR}/.env" | head -1 | sed -E 's/^PROXY_API_KEY="?([^"]*)"?$/\1/')"
-MODELS_RESP=""
-if [ -n "${PROXY_KEY}" ]; then
-    MODELS_RESP="$(curl -sf --max-time 10 "http://127.0.0.1:${PORT}/v1/models" -H "Authorization: Bearer ${PROXY_KEY}" 2>/dev/null || true)"
-else
-    MODELS_RESP="$(curl -sf --max-time 10 "http://127.0.0.1:${PORT}/v1/models" 2>/dev/null || true)"
-fi
-
+step "Authenticated smoke test"
+MODELS_RESP="$(curl -fsS --max-time 10 "http://127.0.0.1:${PORT}/v1/models" -H "Authorization: Bearer ${PROXY_KEY}" || true)"
 if [ -n "${MODELS_RESP}" ]; then
     MODEL_COUNT="$(printf '%s' "${MODELS_RESP}" | grep -o '"id"' | wc -l | tr -d ' ')"
-    log "Models endpoint responded. ~${MODEL_COUNT} models available."
+    log "Models endpoint responded; approximately ${MODEL_COUNT} models returned."
 else
-    log "WARNING: /v1/models returned empty or failed. The service is up (/health ok) but"
-    log "no providers may be configured. Check your .env keys and restart:"
-    log "  sudo systemctl restart ${SERVICE_NAME}"
+    log "Gateway is healthy but /v1/models did not return data. Check provider credentials and journalctl."
 fi
 
-# ---- firewall reminder ------------------------------------------------------
-step "Firewall reminder"
-PUBLIC_IP="$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || true)"
-if [ -n "${PUBLIC_IP}" ]; then
-    log "Your VPS public IP appears to be: ${PUBLIC_IP}"
-fi
-log "Port ${PORT} must be open in the Oracle Cloud security list (Ingress, TCP,"
-log "source = your IP/32 or a Tailscale range). See SETUP_GUIDE.md Step 1.5."
-log "Do NOT open it to 0.0.0.0/0 unless you accept that the gateway is reachable"
-log "by anyone (even with a PROXY_API_KEY, that is not recommended)."
-
-# ---- done -------------------------------------------------------------------
-step "Done"
 cat <<DONEEOF
 
-============================================================
-  Your free LLM gateway is live.
+Gateway is running only at http://127.0.0.1:${PORT}/v1.
 
-  Local URL:   http://127.0.0.1:${PORT}/v1
-  Public URL:  http://${PUBLIC_IP:-YOUR_VPS_IP}:${PORT}/v1
-  API key:     the PROXY_API_KEY you set in ${REPO_DIR}/.env
-  Logs:        sudo journalctl -u ${SERVICE_NAME} -f
-               (or: tail -f ${LOG_FILE})
-  Restart:     sudo systemctl restart ${SERVICE_NAME}
-  Status:      sudo systemctl status ${SERVICE_NAME}
+For personal remote access, use an SSH tunnel from your client:
+  ssh -N -L ${PORT}:127.0.0.1:${PORT} ${RUN_USER}@YOUR_SERVER
 
-  Next steps:
-    1. Open port ${PORT} in the Oracle security list (see SETUP_GUIDE.md 1.5)
-    2. Point your tools at the Public URL above (see SETUP_GUIDE.md Step 5)
-    3. Test a chat completion:
-       curl -X POST http://${PUBLIC_IP:-YOUR_VPS_IP}:${PORT}/v1/chat/completions \\
-         -H "Content-Type: application/json" \\
-         -H "Authorization: Bearer YOUR_PROXY_API_KEY" \\
-         -d '{"model":"coding-elite","messages":[{"role":"user","content":"Hello"}],"max_tokens":50}'
-============================================================
+Then point the client to http://127.0.0.1:${PORT}/v1.
+For internet-facing access, configure an HTTPS reverse proxy on ports 80/443
+that forwards to 127.0.0.1:${PORT}. Never expose TCP/${PORT} directly.
+
+Logs:    sudo journalctl -u ${SERVICE_NAME} -f
+Restart: sudo systemctl restart ${SERVICE_NAME}
+Status:  sudo systemctl status ${SERVICE_NAME}
 DONEEOF


### PR DESCRIPTION
## What

Clean re-submission of the PR #301 bundle hardening. PR #301 was closed without merge because its branch had accumulated unrelated scratch WIP; this minimal 7-file branch contains ONLY the gumroad-bundle hardening, cherry-picked clean off current `origin/main`.

## Changes (cherry-pick of `93e40c9`)

| File | +/- |
|---|---|
| `gumroad-bundle/.env.starter` | -144 |
| `gumroad-bundle/CHANGELOG.md` | -45 |
| `gumroad-bundle/GUMROAD_LISTING.md` | -222 |
| `gumroad-bundle/README.md` | +81/-... |
| `gumroad-bundle/SETUP_GUIDE.md` | -600 |
| `gumroad-bundle/package-release.sh` | +50 (NEW) |
| `gumroad-bundle/quickstart.sh` | +239/... |

**Net: +365 / -1062** — substantial trimming + adds a deterministic packaging script.

## Verified locally

- `git diff --stat origin/main HEAD` = 7 files, only `gumroad-bundle/*`.
- `bash -n gumroad-bundle/package-release.sh` clean.
- `OUT_DIR=/tmp/... bash package-release.sh` produced:
  ```
  free-llm-gateway-starter-kit-v1.0.0.zip       10.7K
  free-llm-gateway-starter-kit-v1.0.0.zip.sha256   106B
  ```
  with SHA256 checksum + integrity test (zip.testzip() passes).
- Gitleaks: 4 reported findings are the same verified-benign FPs already allowlisted via `.gitleaks/config.toml` from #302 (`.env.example` placeholder + public OAuth installed-app CLIENT_SECRETs in 4 `*_auth_base.py` per RFC 8252). With `--config .gitleaks/config.toml` -> **0 leaks**.

## Why a new PR instead of reopening #301

PR #301 branch `docs/gateway-starter-kit` had piled up unrelated WIP commits (.github/workflows, config/virtual_models.yaml, scripts/*, tests/*). Reopening it would bring back that scratch. This clean cherry-pick isolates only the bundle work — easier review, lower risk.

## Refs

- Task-board #416 (this PR is the Step 1 merge + Step 2 packaging).
- Closes-prior PR #301 (closed-without-merge).
- Pricing/brand/listing decisions remain user-gated (#416 Steps 3-5).
