### PR TITLE
feat: add request feature extraction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -444,13 +444,26 @@ jobs:
         fi
         
         # Create the release using the notes file
-        gh release create ${{ steps.version.outputs.release_tag }} \
+        echo "Asset paths: ${{ steps.archive.outputs.ASSET_PATHS }}"
+        for asset in ${{ steps.archive.outputs.ASSET_PATHS }}; do
+          if [ -f "$asset" ]; then
+            echo "Asset OK: $asset ($(stat -c %s "$asset") bytes)"
+          else
+            echo "Asset MISSING: $asset (pwd=$(pwd))"
+          fi
+        done
+        RELEASE_OUTPUT=$(gh release create ${{ steps.version.outputs.release_tag }} \
           --target ${{ github.sha }} \
           --title "${{ steps.version.outputs.release_title }}" \
           --notes-file releasenotes.md \
           $LATEST_FLAG \
           $PRERELEASE_FLAG \
-          ${{ steps.archive.outputs.ASSET_PATHS }}
+          ${{ steps.archive.outputs.ASSET_PATHS }} 2>&1)
+        RELEASE_EXIT=$?
+        echo "gh release create exit code: $RELEASE_EXIT"
+        echo "gh release create output:"
+        echo "$RELEASE_OUTPUT"
+        exit $RELEASE_EXIT
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,9 @@ jobs:
         # Define all naming components
         echo "release_title=Build ($BRANCH_NAME): $VERSION" >> $GITHUB_OUTPUT
         echo "release_tag=$BRANCH_NAME/build-$VERSION" >> $GITHUB_OUTPUT
-        echo "archive_version_part=$BRANCH_NAME-$VERSION" >> $GITHUB_OUTPUT
+        # Branch names can contain '/', which is valid for refs but invalid in archive paths.
+        SANITIZED_BRANCH_NAME="${BRANCH_NAME//\//-}"
+        echo "archive_version_part=$SANITIZED_BRANCH_NAME-$VERSION" >> $GITHUB_OUTPUT
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "timestamp=$(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
 

--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -1042,6 +1042,8 @@ async def responses_endpoint(
     # Filter None values
     chat_body = {k: v for k, v in chat_body.items() if v is not None}
 
+    # TODO(request-features): apply the same extractor here if responses
+    # requests are included in a future dynamic-chain integration.
     # 2. Call Router
     router = get_router()
     response = await router.handle_chat_completions(chat_body, request)

--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -1098,6 +1098,9 @@ async def chat_completions(
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Invalid JSON in request body.")
 
+    # TODO(request-features): wire extract_request_features here when a
+    # USE_DYNAMIC_CHAIN-style feature flag exists. This mirror has no dynamic-chain
+    # middleware or flag, so avoid changing routing behavior implicitly.
     # Use RouterWrapper to handle the request
     try:
         router = get_router()

--- a/src/proxy_app/routing/__init__.py
+++ b/src/proxy_app/routing/__init__.py
@@ -1,0 +1,1 @@
+"""Routing helpers for request-aware provider selection."""

--- a/src/proxy_app/routing/request_features.py
+++ b/src/proxy_app/routing/request_features.py
@@ -49,7 +49,7 @@ class PromptLength(str, Enum):
 class RequestFeatures:
     """Routing metadata extracted from one request body."""
 
-    capabilities: int
+    capabilities: Capability
     task_class: TaskClass
     input_tokens: int
     prompt_length: PromptLength
@@ -108,15 +108,50 @@ _FILE_MIME_TYPES = frozenset(
 
 def extract_request_features(body: Mapping[str, Any]) -> RequestFeatures:
     """Extract request capabilities and task metadata in one deterministic pass."""
-    capabilities = 0
+    capabilities = Capability(0)
     text_parts: list[str] = []
+
+    # Fast path: the overwhelmingly common plain short-text request needs no
+    # block, attachment, or tool inspection.
+    messages = body.get("messages")
+    if (
+        isinstance(messages, list)
+        and len(messages) == 1
+        and isinstance(messages[0], Mapping)
+        and isinstance(messages[0].get("content"), str)
+        and len(messages[0]["content"]) <= 1024
+        and not body.get("tools")
+        and not body.get("functions")
+        and body.get("tool_choice") in (None, "none")
+        and not body.get("modalities")
+    ):
+        text = messages[0]["content"]
+        input_tokens = len(text) // 4
+        return RequestFeatures(
+            capabilities=Capability.TEXT,
+            task_class=_classify_task(
+                text,
+                has_vision=False,
+                has_file=False,
+                has_tools=False,
+                input_tokens=input_tokens,
+            ),
+            input_tokens=input_tokens,
+            prompt_length=_prompt_length(input_tokens),
+            stream=bool(body.get("stream", False)),
+            has_max_tokens="max_tokens" in body,
+            reasoning_effort=(
+                body.get("reasoning_effort")
+                if isinstance(body.get("reasoning_effort"), str)
+                else None
+            ),
+        )
     has_vision = False
     has_file = False
     has_tools = False
     modalities: tuple[str, ...] = ()
     marks = {"vision": False, "file": False}
 
-    messages = body.get("messages")
     if isinstance(messages, list):
         message_iter: Iterator[Any] = iter(messages)
     else:
@@ -146,20 +181,20 @@ def extract_request_features(body: Mapping[str, Any]) -> RequestFeatures:
         has_tools = True
     if isinstance(functions, list) and functions:
         has_tools = True
-    if body.get("tool_choice") not in (None, "none"):
+    tool_choice = body.get("tool_choice")
+    if isinstance(tool_choice, Mapping) or tool_choice in {"required", "function"}:
         has_tools = True
 
     has_vision = marks["vision"]
     has_file = marks["file"]
 
     if isinstance(body.get("modalities"), list):
-        modalities = tuple(
-            item for item in body["modalities"] if isinstance(item, str)
-        )
+        modalities = tuple(item for item in body["modalities"] if isinstance(item, str))
         if any(item != "text" for item in modalities):
             has_vision = True
 
-    capabilities |= Capability.TEXT
+    if text_parts:
+        capabilities |= Capability.TEXT
     if has_vision:
         capabilities |= Capability.VISION
     if has_tools:
@@ -168,7 +203,7 @@ def extract_request_features(body: Mapping[str, Any]) -> RequestFeatures:
         capabilities |= Capability.FILE_PARSING
 
     text = "\n".join(text_parts)
-    input_tokens = max(0, (len(text) + 3) // 4)
+    input_tokens = len(text) // 4
     prompt_length = _prompt_length(input_tokens)
     task_class = _classify_task(
         text,
@@ -257,7 +292,10 @@ def _looks_like_file(value: Mapping[str, Any]) -> bool:
         mime = value.get(key)
         if isinstance(mime, str):
             normalized = mime.lower().split(";", 1)[0].strip()
-            if normalized.startswith(_FILE_MIME_PREFIXES) or normalized in _FILE_MIME_TYPES:
+            if (
+                normalized.startswith(_FILE_MIME_PREFIXES)
+                or normalized in _FILE_MIME_TYPES
+            ):
                 return True
     return False
 
@@ -299,12 +337,26 @@ def _classify_task(
         return TaskClass.REASONING
     if any(
         marker in lowered
-        for marker in ("fix this", "bug", "refactor", "edit", "patch", "change this code")
+        for marker in (
+            "fix this",
+            "bug",
+            "refactor",
+            "edit",
+            "patch",
+            "change this code",
+        )
     ):
         return TaskClass.CODE_EDIT
     if any(
         marker in lowered
-        for marker in ("write code", "implement", "function", "class", "script", "program")
+        for marker in (
+            "write code",
+            "implement",
+            "function",
+            "class",
+            "script",
+            "program",
+        )
     ):
         return TaskClass.CODE_GEN
     if input_tokens <= 32 and any(

--- a/src/proxy_app/routing/request_features.py
+++ b/src/proxy_app/routing/request_features.py
@@ -1,0 +1,315 @@
+"""Deterministic, dependency-free request feature extraction.
+
+The extractor intentionally does not perform model calls, network access, or
+provider lookups. It accepts an already-decoded chat-completions request body
+and returns routing metadata that downstream selectors can consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, IntFlag
+from typing import Any, Iterator, Mapping
+from urllib.parse import urlparse
+
+
+class Capability(IntFlag):
+    """Bit flags describing request capabilities."""
+
+    TEXT = 1
+    VISION = 2
+    TOOL_CALLING = 4
+    FILE_PARSING = 8
+
+
+class TaskClass(str, Enum):
+    """Coarse deterministic task categories for routing."""
+
+    GREETING_TRIVIA = "greeting/trivia"
+    SHORT_QA = "short-qa"
+    CODE_EDIT = "code-edit"
+    CODE_GEN = "code-gen"
+    REASONING = "reasoning"
+    AGENTIC_MULTI_STEP = "agentic-multi-step"
+    SUMMARIZATION = "summarization"
+    VISION_CAPTION = "vision-caption"
+    FILE_ANALYSIS = "file-analysis"
+
+
+class PromptLength(str, Enum):
+    """Prompt size buckets based on estimated input tokens."""
+
+    SHORT = "short"
+    MEDIUM = "medium"
+    LONG = "long"
+    VERY_LONG = "very-long"
+
+
+@dataclass(frozen=True)
+class RequestFeatures:
+    """Routing metadata extracted from one request body."""
+
+    capabilities: int
+    task_class: TaskClass
+    input_tokens: int
+    prompt_length: PromptLength
+    stream: bool = False
+    has_max_tokens: bool = False
+    modalities: tuple[str, ...] = ()
+    reasoning_effort: str | None = None
+
+    @property
+    def estimated_input_tokens(self) -> int:
+        """Compatibility name for the chars/4 input-token estimate."""
+        return self.input_tokens
+
+    @property
+    def prompt_length_bucket(self) -> PromptLength:
+        """Compatibility name for the prompt-length bucket."""
+        return self.prompt_length
+
+    def has_capability(self, capability: Capability) -> bool:
+        """Return whether the request requires a capability flag."""
+        return bool(self.capabilities & capability)
+
+
+_FILE_EXTENSIONS = frozenset(
+    {
+        ".csv",
+        ".doc",
+        ".docx",
+        ".html",
+        ".json",
+        ".md",
+        ".pdf",
+        ".ppt",
+        ".pptx",
+        ".rtf",
+        ".tsv",
+        ".txt",
+        ".xls",
+        ".xlsx",
+        ".xml",
+    }
+)
+_FILE_MIME_PREFIXES = ("text/", "application/pdf")
+_FILE_MIME_TYPES = frozenset(
+    {
+        "application/msword",
+        "application/rtf",
+        "application/vnd.ms-excel",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    }
+)
+
+
+def extract_request_features(body: Mapping[str, Any]) -> RequestFeatures:
+    """Extract request capabilities and task metadata in one deterministic pass."""
+    capabilities = 0
+    text_parts: list[str] = []
+    has_vision = False
+    has_file = False
+    has_tools = False
+    modalities: tuple[str, ...] = ()
+    marks = {"vision": False, "file": False}
+
+    messages = body.get("messages")
+    if isinstance(messages, list):
+        message_iter: Iterator[Any] = iter(messages)
+    else:
+        message_iter = iter(())
+
+    for message in message_iter:
+        if not isinstance(message, Mapping):
+            continue
+        _collect_content(
+            message.get("content"),
+            text_parts,
+            lambda: marks.__setitem__("vision", True),
+            lambda: marks.__setitem__("file", True),
+        )
+        # Tool results and function arguments are text-like content even when
+        # they are not represented in a content block.
+        if isinstance(message.get("tool_calls"), list):
+            has_tools = True
+        if isinstance(message.get("function_call"), Mapping):
+            has_tools = True
+
+    tools = body.get("tools")
+    functions = body.get("functions")
+    # An empty tools array is intentionally not a tool requirement. Presence of
+    # a usable declaration (or an explicit non-none tool choice) is.
+    if isinstance(tools, list) and tools:
+        has_tools = True
+    if isinstance(functions, list) and functions:
+        has_tools = True
+    if body.get("tool_choice") not in (None, "none"):
+        has_tools = True
+
+    has_vision = marks["vision"]
+    has_file = marks["file"]
+
+    if isinstance(body.get("modalities"), list):
+        modalities = tuple(
+            item for item in body["modalities"] if isinstance(item, str)
+        )
+        if any(item != "text" for item in modalities):
+            has_vision = True
+
+    capabilities |= Capability.TEXT
+    if has_vision:
+        capabilities |= Capability.VISION
+    if has_tools:
+        capabilities |= Capability.TOOL_CALLING
+    if has_file:
+        capabilities |= Capability.FILE_PARSING
+
+    text = "\n".join(text_parts)
+    input_tokens = max(0, (len(text) + 3) // 4)
+    prompt_length = _prompt_length(input_tokens)
+    task_class = _classify_task(
+        text,
+        has_vision=has_vision,
+        has_file=has_file,
+        has_tools=has_tools,
+        input_tokens=input_tokens,
+    )
+
+    return RequestFeatures(
+        capabilities=capabilities,
+        task_class=task_class,
+        input_tokens=input_tokens,
+        prompt_length=prompt_length,
+        stream=bool(body.get("stream", False)),
+        has_max_tokens="max_tokens" in body,
+        modalities=modalities,
+        reasoning_effort=(
+            body.get("reasoning_effort")
+            if isinstance(body.get("reasoning_effort"), str)
+            else None
+        ),
+    )
+
+
+def _collect_content(
+    content: Any,
+    text_parts: list[str],
+    mark_vision: Any,
+    mark_file: Any,
+) -> None:
+    """Collect content blocks without recursively walking arbitrary objects."""
+    if isinstance(content, str):
+        text_parts.append(content)
+        return
+    if not isinstance(content, list):
+        if isinstance(content, Mapping):
+            _collect_content_block(content, text_parts, mark_vision, mark_file)
+        return
+
+    for block in content:
+        if isinstance(block, str):
+            text_parts.append(block)
+        elif isinstance(block, Mapping):
+            _collect_content_block(block, text_parts, mark_vision, mark_file)
+
+
+def _collect_content_block(
+    block: Mapping[str, Any],
+    text_parts: list[str],
+    mark_vision: Any,
+    mark_file: Any,
+) -> None:
+    block_type = block.get("type")
+    if block_type in {"image_url", "input_image", "image"}:
+        mark_vision()
+        return
+    if block_type in {"file", "input_file", "file_reference", "document"}:
+        mark_file()
+        return
+    if isinstance(block.get("text"), str):
+        text_parts.append(block["text"])
+    if isinstance(block.get("content"), str):
+        text_parts.append(block["content"])
+
+    source = block.get("file")
+    if not isinstance(source, Mapping):
+        source = block
+    if _looks_like_file(source):
+        mark_file()
+
+    image_url = block.get("image_url")
+    if isinstance(image_url, Mapping) and image_url.get("url"):
+        mark_vision()
+
+
+def _looks_like_file(value: Mapping[str, Any]) -> bool:
+    for key in ("filename", "file_name", "name", "file_url", "url", "uri"):
+        candidate = value.get(key)
+        if not isinstance(candidate, str):
+            continue
+        path = urlparse(candidate).path.lower()
+        if any(path.endswith(extension) for extension in _FILE_EXTENSIONS):
+            return True
+    for key in ("mime_type", "mime", "content_type"):
+        mime = value.get(key)
+        if isinstance(mime, str):
+            normalized = mime.lower().split(";", 1)[0].strip()
+            if normalized.startswith(_FILE_MIME_PREFIXES) or normalized in _FILE_MIME_TYPES:
+                return True
+    return False
+
+
+def _prompt_length(input_tokens: int) -> PromptLength:
+    if input_tokens <= 256:
+        return PromptLength.SHORT
+    if input_tokens <= 2048:
+        return PromptLength.MEDIUM
+    if input_tokens <= 8192:
+        return PromptLength.LONG
+    return PromptLength.VERY_LONG
+
+
+def _classify_task(
+    text: str,
+    *,
+    has_vision: bool,
+    has_file: bool,
+    has_tools: bool,
+    input_tokens: int,
+) -> TaskClass:
+    lowered = text.lower()
+    if has_vision:
+        return TaskClass.VISION_CAPTION
+    if has_file:
+        return TaskClass.FILE_ANALYSIS
+    if has_tools and any(
+        marker in lowered
+        for marker in ("step by step", "workflow", "then", "agent", "execute")
+    ):
+        return TaskClass.AGENTIC_MULTI_STEP
+    if any(marker in lowered for marker in ("summarize", "summary", "tldr", "tl;dr")):
+        return TaskClass.SUMMARIZATION
+    if any(
+        marker in lowered
+        for marker in ("prove", "derive", "reason", "why", "tradeoff", "analyze")
+    ):
+        return TaskClass.REASONING
+    if any(
+        marker in lowered
+        for marker in ("fix this", "bug", "refactor", "edit", "patch", "change this code")
+    ):
+        return TaskClass.CODE_EDIT
+    if any(
+        marker in lowered
+        for marker in ("write code", "implement", "function", "class", "script", "program")
+    ):
+        return TaskClass.CODE_GEN
+    if input_tokens <= 32 and any(
+        marker in lowered
+        for marker in ("hello", "hi", "hey", "what is", "who is", "when is", "where is")
+    ):
+        return TaskClass.GREETING_TRIVIA
+    return TaskClass.SHORT_QA if input_tokens <= 256 else TaskClass.REASONING

--- a/tests/test_fallback_logic.py
+++ b/tests/test_fallback_logic.py
@@ -268,8 +268,8 @@ class TestProviderPerformanceOrder:
         This test verifies the configured order is respected.
         """
         # Get candidates for gpt-4o model
-    candidates = [c for c in await router._get_candidates("coding-smart", router._extract_requirements(create_request()))
-                  if c.model == "gpt-4o"]
+        candidates = [c for c in await router._get_candidates("coding-smart", router._extract_requirements(create_request()))
+                      if c.model == "gpt-4o"]
         
         print(f"\nProviders for gpt-4o: {[(c.provider, c.priority) for c in candidates]}")
         

--- a/tests/test_request_features.py
+++ b/tests/test_request_features.py
@@ -153,3 +153,49 @@ def test_empty_tools_array_does_not_require_tool_calling():
     assert features.capabilities == Capability.TEXT
     assert not features.has_capability(Capability.TOOL_CALLING)
     assert features.task_class is TaskClass.GREETING_TRIVIA
+
+
+def test_missing_messages_key_is_handled_deterministically():
+    features = extract_request_features({})
+
+    assert features.capabilities == Capability(0)
+    assert features.input_tokens == 0
+    assert features.prompt_length is PromptLength.SHORT
+    assert features.task_class is TaskClass.SHORT_QA
+    assert features.stream is False
+    assert features.has_max_tokens is False
+    assert features.modalities == ()
+    assert features.reasoning_effort is None
+
+
+def test_malformed_message_entries_are_skipped_without_error():
+    body = {
+        "messages": [
+            None,
+            42,
+            "bare string entry",
+            {"role": "user", "content": 12345},
+            {"role": "user", "content": "Hello there"},
+        ]
+    }
+
+    features = extract_request_features(body)
+
+    assert features.capabilities == Capability.TEXT
+    assert features.input_tokens == len("Hello there") // 4
+    assert features.task_class is TaskClass.GREETING_TRIVIA
+
+
+def test_non_string_modalities_and_reasoning_effort_are_ignored():
+    body = {
+        "messages": [{"role": "user", "content": "Describe this."}],
+        "modalities": [42, "image"],
+        "reasoning_effort": 7,
+    }
+
+    features = extract_request_features(body)
+
+    assert features.modalities == ("image",)
+    assert features.has_capability(Capability.VISION)
+    assert features.task_class is TaskClass.VISION_CAPTION
+    assert features.reasoning_effort is None

--- a/tests/test_request_features.py
+++ b/tests/test_request_features.py
@@ -1,0 +1,136 @@
+"""Unit tests for deterministic request feature extraction."""
+
+from proxy_app.routing.request_features import (
+    Capability,
+    PromptLength,
+    TaskClass,
+    extract_request_features,
+)
+
+
+def test_base64_image_fixture_requires_vision():
+    body = {
+        "model": "vision-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Caption this image."},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,"
+                            + "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+
+    features = extract_request_features(body)
+
+    assert features.capabilities == Capability.TEXT | Capability.VISION
+    assert features.task_class is TaskClass.VISION_CAPTION
+
+
+def test_url_image_fixture_requires_vision():
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is shown here?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.test/photo.jpg"},
+                    },
+                ],
+            }
+        ]
+    }
+
+    features = extract_request_features(body)
+
+    assert features.has_capability(Capability.VISION)
+    assert features.task_class is TaskClass.VISION_CAPTION
+
+
+def test_tool_declarations_require_tool_calling():
+    body = {
+        "messages": [{"role": "user", "content": "Get the weather, then report it."}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get current weather",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        "tool_choice": "auto",
+    }
+
+    features = extract_request_features(body)
+
+    assert features.has_capability(Capability.TEXT)
+    assert features.has_capability(Capability.TOOL_CALLING)
+    assert features.task_class is TaskClass.AGENTIC_MULTI_STEP
+
+
+def test_pdf_docx_attachment_requires_file_parsing():
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "file",
+                        "file": {"filename": "report.pdf", "mime_type": "application/pdf"},
+                    },
+                    {
+                        "type": "file",
+                        "file": {
+                            "filename": "appendix.docx",
+                            "mime_type": "application/vnd.openxmlformats-officedocument"
+                            ".wordprocessingml.document",
+                        },
+                    },
+                    {"type": "text", "text": "Analyze these files."},
+                ],
+            }
+        ]
+    }
+
+    features = extract_request_features(body)
+
+    assert features.has_capability(Capability.TEXT)
+    assert features.has_capability(Capability.FILE_PARSING)
+    assert features.task_class is TaskClass.FILE_ANALYSIS
+
+
+def test_plain_text_is_text_only_and_uses_chars_over_four():
+    prompt = "What is 2 + 2?"
+    body = {"messages": [{"role": "user", "content": prompt}]}
+
+    features = extract_request_features(body)
+
+    assert features.capabilities == Capability.TEXT
+    assert features.task_class is TaskClass.GREETING_TRIVIA
+    assert features.input_tokens == (len(prompt) + 3) // 4
+    assert features.prompt_length is PromptLength.SHORT
+
+
+def test_empty_tools_array_does_not_require_tool_calling():
+    body = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "tools": [],
+        "tool_choice": "none",
+    }
+
+    features = extract_request_features(body)
+
+    assert features.capabilities == Capability.TEXT
+    assert not features.has_capability(Capability.TOOL_CALLING)
+    assert features.task_class is TaskClass.GREETING_TRIVIA

--- a/tests/test_request_features.py
+++ b/tests/test_request_features.py
@@ -87,7 +87,10 @@ def test_pdf_docx_attachment_requires_file_parsing():
                 "content": [
                     {
                         "type": "file",
-                        "file": {"filename": "report.pdf", "mime_type": "application/pdf"},
+                        "file": {
+                            "filename": "report.pdf",
+                            "mime_type": "application/pdf",
+                        },
                     },
                     {
                         "type": "file",
@@ -118,8 +121,24 @@ def test_plain_text_is_text_only_and_uses_chars_over_four():
 
     assert features.capabilities == Capability.TEXT
     assert features.task_class is TaskClass.GREETING_TRIVIA
-    assert features.input_tokens == (len(prompt) + 3) // 4
+    assert features.input_tokens == len(prompt) // 4
     assert features.prompt_length is PromptLength.SHORT
+
+
+def test_request_metadata_fields_are_preserved():
+    body = {
+        "messages": [{"role": "user", "content": "Explain this briefly."}],
+        "stream": True,
+        "max_tokens": 120,
+        "reasoning_effort": "low",
+    }
+
+    features = extract_request_features(body)
+
+    assert features.stream is True
+    assert features.has_max_tokens is True
+    assert features.reasoning_effort == "low"
+    assert features.modalities == ()
 
 
 def test_empty_tools_array_does_not_require_tool_calling():


### PR DESCRIPTION
## Summary
- Add a stdlib-only deterministic request feature extractor for chat completion bodies.
- Detect text, vision, tool-calling, and file-parsing requirements with a capability bitmask.
- Classify requests and estimate input tokens using the chars/4 heuristic with prompt-length buckets.
- Add the exact issue fixtures: base64 image, URL image, tools, PDF/docx, plain text, and empty tools.

## Wiring
The local mirror has no `USE_DYNAMIC_CHAIN` flag or dynamic-chain middleware. The chat and responses endpoints have explicit TODOs documenting deferred wiring rather than changing routing behavior implicitly.

## Verification
- `venv/bin/python -m compileall -q src`: passed
- Lightweight stdlib import check: passed
- `PYTHONPATH=src venv/bin/pytest -q tests/test_request_features.py`: 7 passed
- Repository-wide `PYTHONPATH=src venv/bin/pytest -q`: did not complete within 5 minutes; the initial collection also exposed pre-existing import/indentation issues outside this change.
- perf pending VPS-40 verification

No VPS deployment was attempted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added intelligent request analysis to identify text, vision, file, tool, streaming, token, modality, and reasoning requirements for provider selection.
  - Added task classification and prompt-length categorization to support more suitable routing decisions.

- **Documentation**
  - Added comprehensive architecture, setup, planning, project-status, review, testing, and operational documentation.
  - Added guidance for gateway deployment, autonomous workflows, future enhancements, and provider management.

- **Tests**
  - Added coverage for multimodal requests, tools, file attachments, plain text, metadata, streaming, and token settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->