### PR TITLE
feat(routing): dynamic per-task-class max_tokens budget (#479)

### DIFF
--- a/config/token_budget.yaml
+++ b/config/token_budget.yaml
@@ -1,0 +1,33 @@
+# Per-task-class max_tokens budget (#479) - "speed guarantee" lever.
+#
+# Small tasks must not burn the full 4096-token default. This map sets a sane
+# per-class ceiling that is applied to outgoing upstream requests ONLY when the
+# client did not provide its own max_tokens (user intent always wins).
+#
+# The effective cap is:  min(class_default * tier_multiplier,
+#                            context_limit - estimated_input_tokens - safety_margin)
+#
+# Class defaults (tokens) - tune here or via TOKEN_BUDGET_OVERRIDES env JSON.
+class_defaults:
+  greeting: 128
+  short-qa: 512
+  code-edit: 1024
+  code-gen: 2048
+  reasoning: 4096
+  agentic-multi-step: 8192
+  summarization: 1500
+  vision-caption: 512
+  file-analysis: 2048
+
+# Tier multipliers: T0-T1 get the class default; higher tiers may raise the cap
+# within the context-limit clamp. Keyed by tier index (int) matching
+# tier_classifier tiers.
+tier_multiplier:
+  "0": 1.0
+  "1": 1.0
+  "2": 1.2
+  "3": 1.5
+  "4": 2.0
+
+# Reserve headroom so input + output stays within the provider context window.
+safety_margin: 256

--- a/src/proxy_app/router_core.py
+++ b/src/proxy_app/router_core.py
@@ -2724,6 +2724,39 @@ class RouterCore:
                 _tier = _classify(
                     _features, header_override=request.get("x-route-tier")
                 )
+                # #479: per-task-class max_tokens budget ("speed guarantee").
+                # Computed whenever the smart-router stack is active; the
+                # outgoing request is mutated only in ROUTER_ENABLED mode
+                # (dry-run just logs X-Route-Max-Tokens). Never overrides an
+                # explicit client-supplied max_tokens.
+                try:
+                    from proxy_app.routing.token_budget import (
+                        apply_token_budget,
+                        FALLBACK_CONTEXT_LIMIT,
+                    )
+
+                    _caps = _load_provider_caps()
+                    _ctxs = [
+                        ((_caps.get(c.provider, {}) or {}).get("max_context_tokens", 0))
+                        for c in available_candidates
+                    ]
+                    _ctx_limit = max([x for x in _ctxs if x] or [FALLBACK_CONTEXT_LIMIT])
+                    _budget_hdr = apply_token_budget(
+                        request,
+                        _features,
+                        _ctx_limit,
+                        tier=int(_tier),
+                        budget_config=os.path.join(
+                            os.path.dirname(self.config_path), "token_budget.yaml"
+                        ),
+                        enabled=self._router_enabled,
+                    )
+                    if _budget_hdr:
+                        logger.info("[%s] X-Route-Max-Tokens: %s", request_id, _budget_hdr)
+                except Exception as _budget_exc:
+                    logger.debug(
+                        "[%s] token budget skipped: %s", request_id, _budget_exc
+                    )
                 _selector = self._smart_selectors.get(
                     request.get("model", ""), self._smart_default
                 )

--- a/src/proxy_app/routing/__init__.py
+++ b/src/proxy_app/routing/__init__.py
@@ -38,6 +38,15 @@ from .chain_selector import (
     to_debug_header,
 )
 
+from .token_budget import (
+    CLASS_DEFAULTS,
+    FALLBACK_CONTEXT_LIMIT,
+    FLOOR_TOKEN_BUDGET,
+    apply_token_budget,
+    compute_max_tokens,
+    load_budget_config,
+)
+
 __all__ = [
     "Capabilities",
     "PromptBucket",
@@ -62,4 +71,10 @@ __all__ = [
     "load_virtual_chain",
     "on_error",
     "to_debug_header",
+    "CLASS_DEFAULTS",
+    "FALLBACK_CONTEXT_LIMIT",
+    "FLOOR_TOKEN_BUDGET",
+    "apply_token_budget",
+    "compute_max_tokens",
+    "load_budget_config",
 ]

--- a/src/proxy_app/routing/token_budget.py
+++ b/src/proxy_app/routing/token_budget.py
@@ -1,0 +1,177 @@
+"""Per-task-class max_tokens budget for the smart router (#479).
+
+"Speed guarantee": total latency = TTFT + tokens/TPS, so the cheapest lever is
+to stop small tasks from generating massive outputs. A greeting must not burn
+4096 tokens (the LiteLLM/fallback default).
+
+Computes an intelligent per-request ``max_tokens`` cap based on the request's
+task class (from ``request_features``) and tier, then clamps it to the
+provider's context window minus the estimated input tokens.
+
+Rules (see task-board #479):
+  * Applied ONLY when the client did NOT supply its own ``max_tokens`` /
+    ``max_completion_tokens`` - user intent always wins (never overridden).
+  * ``max_tokens <= model_context_limit - estimated_input_tokens - safety_margin``.
+  * Config map: ``config/token_budget.yaml`` (class defaults + tier multipliers),
+    overridable at runtime via the ``TOKEN_BUDGET_OVERRIDES`` env (JSON string
+    mapping task_class -> int).
+  * Returns an ``X-Route-Max-Tokens`` header value for debug/dry-run surfacing.
+
+Pure functions plus a thin config loader; stdlib-only (pyyaml for the config is
+already a project dependency). Safe to import without the full router.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+DEFAULT_SAFETY_MARGIN = 256
+
+# Built-in defaults (mirror config/token_budget.yaml). task_class values match
+# request_features.TaskClass. A missing class falls back to a conservative 512.
+CLASS_DEFAULTS: Dict[str, int] = {
+    "greeting": 128,
+    "short-qa": 512,
+    "code-edit": 1024,
+    "code-gen": 2048,
+    "reasoning": 4096,
+    "agentic-multi-step": 8192,
+    "summarization": 1500,
+    "vision-caption": 512,
+    "file-analysis": 2048,
+}
+
+# FLOOR if the clamp ceiling (context - input - margin) is unhelpfully small
+# (e.g. a degenerate request whose input already exceeds the context window).
+FLOOR_TOKEN_BUDGET = 16
+
+# Largest provider context to assume when provider_caps.yaml is missing/empty.
+FALLBACK_CONTEXT_LIMIT = 128_000
+
+
+def load_budget_config(path: Optional[str] = None) -> Dict[str, Any]:
+    """Merge a token_budget.yaml (if present) over the built-in defaults.
+
+    Returns {'class_defaults': {...}, 'tier_multiplier': {...},
+             'safety_margin': int}.
+    """
+    cfg: Dict[str, Any] = {
+        "class_defaults": dict(CLASS_DEFAULTS),
+        "tier_multiplier": {"0": 1.0, "1": 1.0, "2": 1.2, "3": 1.5, "4": 2.0},
+        "safety_margin": DEFAULT_SAFETY_MARGIN,
+    }
+    if path:
+        p = Path(path)
+        if p.exists():
+            try:
+                import yaml
+
+                data = yaml.safe_load(p.read_text()) or {}
+                cdefs = data.get("class_defaults") or {}
+                if isinstance(cdefs, dict):
+                    cfg["class_defaults"].update(cdefs)
+                tm = data.get("tier_multiplier") or {}
+                if isinstance(tm, dict):
+                    cfg["tier_multiplier"].update({str(k): float(v) for k, v in tm.items()})
+                sm = data.get("safety_margin")
+                if isinstance(sm, (int, float)):
+                    cfg["safety_margin"] = int(sm)
+            except Exception:
+                pass
+    return cfg
+
+
+def env_overrides() -> Dict[str, int]:
+    """Parse TOKEN_BUDGET_OVERRIDES env as JSON {task_class: int}."""
+    raw = os.environ.get("TOKEN_BUDGET_OVERRIDES", "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        return {str(k).lower(): int(v) for k, v in parsed.items() if isinstance(v, (int, float))}
+    except Exception:
+        return {}
+
+
+def _tier_multiplier(tier: Optional[int], tm: Dict[str, float]) -> float:
+    if tier is None:
+        return 1.0
+    return float(tm.get(str(tier), 1.0))
+
+
+def compute_max_tokens(
+    task_class: str,
+    estimated_input_tokens: int,
+    context_limit: int,
+    *,
+    tier: Optional[int] = None,
+    class_defaults: Optional[Dict[str, int]] = None,
+    tier_multiplier: Optional[Dict[str, float]] = None,
+    safety_margin: int = DEFAULT_SAFETY_MARGIN,
+    overrides: Optional[Dict[str, int]] = None,
+) -> int:
+    """Return the effective max_tokens cap for a request's task class.
+
+    ``context_limit`` is the provider's max context window (tokens). The result
+    is always >= FLOOR_TOKEN_BUDGET and <= class_default.
+    """
+    overrides = overrides or env_overrides()
+    base = overrides.get(task_class) or (class_defaults or CLASS_DEFAULTS).get(task_class, 512)
+    mult = _tier_multiplier(tier, tier_multiplier or {})
+    base = max(1, int(round(base * mult)))
+
+    ceiling = max(
+        FLOOR_TOKEN_BUDGET,
+        context_limit - int(estimated_input_tokens or 0) - int(safety_margin),
+    )
+    return max(FLOOR_TOKEN_BUDGET, min(base, ceiling))
+
+
+def apply_token_budget(
+    request: Dict[str, Any],
+    features,
+    context_limit: int,
+    *,
+    tier: Optional[int] = None,
+    budget_config: Optional[str] = None,
+    enabled: bool = False,
+) -> Optional[str]:
+    """Apply the token budget to ``request`` in place.
+
+    Returns an ``X-Route-Max-Tokens`` debug header string (or None if the
+    client supplied its own max_tokens / nothing to cap). ``request`` is only
+    mutated (``max_tokens`` set) when ``enabled=True`` (ROUTER_ENABLED); when
+    ``enabled=False`` the value is still computed and returned so dry-run callers
+    can log the intended cap without changing the outgoing request.
+
+    ``features`` must expose ``task_class``, ``estimated_input_tokens`` and
+    ``has_max_tokens`` (a RequestFeatures instance).
+    """
+    if getattr(features, "has_max_tokens", False):
+        return None
+
+    cfg = load_budget_config(budget_config)
+    task = features.task_class.value if hasattr(features.task_class, "value") else str(features.task_class)
+    cap = compute_max_tokens(
+        task,
+        getattr(features, "estimated_input_tokens", 0),
+        context_limit,
+        tier=tier,
+        class_defaults=cfg["class_defaults"],
+        tier_multiplier=cfg["tier_multiplier"],
+        safety_margin=cfg["safety_margin"],
+    )
+
+    header = f"{cap}"
+    if enabled:
+        # OpenAI-compat: update the key the client/request actually uses.
+        if "max_completion_tokens" in request:
+            request["max_completion_tokens"] = cap
+        else:
+            request["max_tokens"] = cap
+        header += " (applied)"
+    else:
+        header += " (dry-run, not applied)"
+    return header

--- a/tests/test_token_budget.py
+++ b/tests/test_token_budget.py
@@ -1,0 +1,118 @@
+"""Tests for src/proxy_app/routing/token_budget.py — task-board #479.
+
+Verifies:
+- Per-class max_tokens defaults (greeting small, code-gen larger)
+- Context-limit clamping edge cases (huge input, tiny context)
+- Tier multiplier raises cap within the clamp
+- Explicit client max_tokens is NEVER overridden
+- Dry-run does not mutate the request; enabled mode applies it
+- TOKEN_BUDGET_OVERRIDES env override
+
+Run: python -m pytest tests/test_token_budget.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from proxy_app.routing.request_features import (  # noqa: E402
+    extract_request_features,
+)
+from proxy_app.routing.token_budget import (  # noqa: E402
+    FLOOR_TOKEN_BUDGET,
+    apply_token_budget,
+    compute_max_tokens,
+    env_overrides,
+    load_budget_config,
+)
+
+_REAL_YAML = _REPO_ROOT / "config" / "token_budget.yaml"
+
+
+class TestComputeMaxTokens(unittest.TestCase):
+    def test_per_class_defaults(self):
+        # A greeting must not burn 4096 tokens.
+        self.assertEqual(compute_max_tokens("greeting", 20, 131072), 128)
+        self.assertEqual(compute_max_tokens("short-qa", 30, 131072), 512)
+        self.assertEqual(compute_max_tokens("code-gen", 50, 131072), 2048)
+        self.assertEqual(compute_max_tokens("reasoning", 50, 131072), 4096)
+        self.assertEqual(compute_max_tokens("agentic-multi-step", 50, 131072), 8192)
+
+    def test_unknown_class_falls_back(self):
+        self.assertEqual(compute_max_tokens("mystery-class", 10, 131072), 512)
+
+    def test_context_clamp_small_context(self):
+        # Tiny context forces a hard clamp well below the class default.
+        cap = compute_max_tokens("code-edit", 200, 1024)
+        self.assertLess(cap, 1024)  # clamped by 1024 - 200 - 256 = 568
+
+    def test_context_clamp_huge_input(self):
+        # Input already exceeds context -> floor (never negative/zero).
+        cap = compute_max_tokens("reasoning", 100_000, 8192)
+        self.assertGreaterEqual(cap, FLOOR_TOKEN_BUDGET)
+
+    def test_tier_multiplier_from_config(self):
+        # Through the real config, T4 raises code-edit 1024 -> 2048.
+        cfg = load_budget_config(str(_REAL_YAML))
+        base = compute_max_tokens("code-edit", 200, 131072,
+                                  tier=4,
+                                  tier_multiplier=cfg["tier_multiplier"])
+        self.assertEqual(base, 2048)
+        tier0 = compute_max_tokens("code-edit", 200, 131072,
+                                   tier=0,
+                                   tier_multiplier=cfg["tier_multiplier"])
+        self.assertEqual(tier0, 1024)
+
+    def test_env_override(self):
+        os.environ["TOKEN_BUDGET_OVERRIDES"] = '{"reasoning": 1234}'
+        try:
+            self.assertEqual(env_overrides().get("reasoning"), 1234)
+            self.assertEqual(compute_max_tokens("reasoning", 20, 131072), 1234)
+        finally:
+            del os.environ["TOKEN_BUDGET_OVERRIDES"]
+
+
+class TestApplyTokenBudgetRequest(unittest.TestCase):
+    def _features(self, body):
+        return extract_request_features(body)
+
+    def test_client_max_tokens_never_overridden(self):
+        # Both OpenAI max_tokens and responses max_completion_tokens respect intent.
+        for key in ("max_tokens", "max_completion_tokens"):
+            body = {"model": "x", "messages": [{"role": "user", "content": "hi"}], key: 1}
+            feats = self._features(body)
+            hdr = apply_token_budget(body, feats, 131072, enabled=True)
+            self.assertIsNone(hdr, f"{key} should return None but got {hdr}")
+            self.assertEqual(body[key], 1, f"{key} must not be overridden")
+
+    def test_dry_run_does_not_mutate(self):
+        body = {"model": "x", "messages": [{"role": "user", "content": "hi"}]}
+        feats = self._features(body)
+        hdr = apply_token_budget(body, feats, 131072, enabled=False)
+        self.assertIn("dry-run", hdr)
+        self.assertNotIn("max_tokens", body)  # unchanged in dry-run
+        self.assertNotIn("max_completion_tokens", body)
+
+    def test_enabled_applies_task_class_cap(self):
+        body = {"model": "x", "messages": [{"role": "user", "content": "hello"}]}
+        feats = self._features(body)
+        hdr = apply_token_budget(body, feats, 131072, enabled=True)
+        self.assertIn("applied", hdr)
+        self.assertEqual(body["max_tokens"], 128)  # greeting class
+
+    def test_backs_off_when_absent(self):
+        # No budget changes if features indicate has_max_tokens even pre-parse.
+        body = {"model": "x", "messages": [{"role": "user", "content": "hi"}], "max_completion_tokens": 2048}
+        feats = self._features(body)
+        self.assertIsNone(apply_token_budget(body, feats, 131072, enabled=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the per-task-class max_tokens "speed guarantee" (#479).

**What changed**
- New `src/proxy_app/routing/token_budget.py` (stdlib + pyyaml): per-task-class max_tokens caps, tier multipliers, context-limit clamp, TOKEN_BUDGET_OVERRIDES env override, X-Route-Max-Tokens header value.
- New `config/token_budget.yaml`: class_defaults (greeting 128 ... agentic 8192), tier_multiplier T0-T4, safety_margin.
- `router_core.py` smart-routing hook: computes budget after tier classification, mutates the outgoing request (max_tokens/max_completion_tokens) ONLY in ROUTER_ENABLED=1 mode; dry-run logs X-Route-Max-Tokens. Logs/degrades safely in try/except like the existing #481 stack.
- `routing/__init__.py` exports.
- `tests/test_token_budget.py`: 10 tests (per-class defaults, context clamp edge cases, tier multiplier from config, env override, client max_tokens never overridden, dry-run no-mutation, enabled applies).

**Acceptance**
- [x] Per-class caps applied to upstream when client omits max_tokens
- [x] Explicit client max_tokens always respected (never overridden)
- [x] Context-limit clamping (<= context - input - margin)
- [x] X-Route-Max-Tokens header in dry-run mode (logged)
- [x] Tests pass; zero new deps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable token budgets based on task type, service tier, input size, and provider context limits.
  * Added optional environment overrides and a safety margin for calculated limits.
  * Preserved explicitly requested token limits while applying budgets only when routing is enabled.
  * Added route metadata reporting the applied token limit.

* **Bug Fixes**
  * Budget calculation failures no longer interrupt requests and are logged non-fatally.

* **Tests**
  * Added coverage for defaults, overrides, clamping, dry-run behavior, and request-limit preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->