### PR TITLE
test: fix IndentationError blocking test collection

### DIFF
--- a/tests/test_fallback_logic.py
+++ b/tests/test_fallback_logic.py
@@ -268,8 +268,8 @@ class TestProviderPerformanceOrder:
         This test verifies the configured order is respected.
         """
         # Get candidates for gpt-4o model
-    candidates = [c for c in await router._get_candidates("coding-smart", router._extract_requirements(create_request()))
-                  if c.model == "gpt-4o"]
+        candidates = [c for c in await router._get_candidates("coding-smart", router._extract_requirements(create_request()))
+                      if c.model == "gpt-4o"]
         
         print(f"\nProviders for gpt-4o: {[(c.provider, c.priority) for c in candidates]}")
         


### PR DESCRIPTION
## Summary

Re-indents the `candidates` list comprehension inside `test_fallback_provider_order_by_performance` in `tests/test_fallback_logic.py`. The dedented continuation lines caused an `IndentationError` at import time, which broke collection of the **entire** pytest run — this bug is present on `origin/main` today.

Extracted as a standalone commit from #305 (cherry-pick of 57e4bbc) per the pr-reviewer recommendation on that PR, so the fix isn't lost when #305 closes. It also unblocks the repair work tracked in #764.

## Test evidence

**Pre-fix (origin/main version of the file):**

```
$ python -m py_compile tests/test_fallback_logic.py
Sorry: IndentationError: unexpected indent (tests/test_fallback_logic.py, line 274)
```

**Post-fix (this branch):**

```
$ python -m pytest tests/test_fallback_logic.py --collect-only -q
7 tests collected in 1.65s

$ timeout 180 python -m pytest tests/test_fallback_logic.py -q
6 failed, 1 passed in 5.30s
```

Collection now succeeds (the win). The 6 remaining failures are pre-existing suite drift documented in #764 (`503: No healthy providers available` — router/env drift, unrelated to this indentation change).

## Notes

- Test-file-only change — **no runtime/code change**.
- Heads-up: merging to main auto-deploys to Render (per house rules). Since this PR touches only `tests/test_fallback_logic.py`, there is no runtime impact.
- Extracted from #305 per automated pr-review; final merge decision is Owen's.
