### PR TITLE
fix(router): restore alias chain failover for streaming requests

### DIFF
--- a/src/proxy_app/router_core.py
+++ b/src/proxy_app/router_core.py
@@ -10,6 +10,7 @@ import time
 import json
 import logging
 import hashlib
+import inspect
 from typing import Dict, List, Optional, Any, AsyncGenerator, Union, Tuple
 from dataclasses import dataclass, field
 from enum import Enum
@@ -2563,6 +2564,66 @@ class RouterCore:
                 await asyncio.sleep(backoff)
         raise last_err  # unreachable, but satisfies type checker
 
+    async def _alias_stream_with_fallback(
+        self,
+        request: Dict[str, Any],
+        request_id: str,
+        alias_model: str,
+        candidates: List[Dict[str, str]],
+        initial_stream: AsyncGenerator[Dict[str, Any], None],
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Stream an alias request with per-candidate failover.
+
+        For streaming requests, route_request returns an async generator that
+        has not started yet; provider errors surface during iteration, after
+        the alias loop has already returned. This wrapper restores chain
+        failover by moving to the next alias candidate when the current
+        stream errors, mirroring _stream_with_fallback's semantics.
+        """
+        last_error = None
+        stream = initial_stream
+
+        for idx, candidate_cfg in enumerate(candidates):
+            if idx > 0:
+                candidate_request = request.copy()
+                candidate_request["model"] = (
+                    f"{candidate_cfg['provider']}/{candidate_cfg['model']}"
+                )
+                try:
+                    logger.info(
+                        f"[{request_id}] Alias '{alias_model}' -> Trying "
+                        f"{candidate_cfg['provider']}/{candidate_cfg['model']}"
+                    )
+                    stream = await self.route_request(candidate_request, request_id)
+                except Exception as e:
+                    last_error = e
+                    logger.warning(
+                        f"[{request_id}] Alias chain: {candidate_cfg['provider']}/"
+                        f"{candidate_cfg['model']} failed: {e}"
+                    )
+                    continue
+
+            try:
+                async for chunk in stream:
+                    yield chunk
+                return
+            except Exception as e:
+                last_error = e
+                logger.warning(
+                    f"[{request_id}] Alias chain stream: {candidate_cfg['provider']}/"
+                    f"{candidate_cfg['model']} failed: {e}"
+                )
+                continue
+
+        logger.error(
+            f"[{request_id}] All candidates for alias '{alias_model}' failed."
+        )
+        if last_error:
+            raise last_error
+        raise HTTPException(
+            status_code=503, detail=f"All providers for alias '{alias_model}' failed"
+        )
+
     async def _route_request_inner(
         self, request: Dict[str, Any], request_id: str
     ) -> Union[Dict[str, Any], AsyncGenerator[Dict[str, Any], None]]:
@@ -2594,7 +2655,16 @@ class RouterCore:
                     # Recursively call route_request (but now with a resolved explicit model)
                     # We avoid infinite recursion because the new model id (e.g. "openai/gpt-4")
                     # won't match an alias key in the next pass.
-                    return await self.route_request(candidate_request, request_id)
+                    result = await self.route_request(candidate_request, request_id)
+
+                    if inspect.isasyncgen(result):
+                        # Streaming: the generator has not started, so provider
+                        # errors would surface after this loop returns. Hand the
+                        # chain to the wrapper so failover still happens.
+                        return self._alias_stream_with_fallback(
+                            request, request_id, model_id, alias_candidates, result
+                        )
+                    return result
 
                 except Exception as e:
                     last_error = e

--- a/tests/test_alias_stream_fallback.py
+++ b/tests/test_alias_stream_fallback.py
@@ -1,0 +1,133 @@
+"""
+Alias streaming fallback tests.
+
+Regression tests for the alias chain: for streaming requests, route_request
+returns an async generator that has not started yet, so provider errors
+surface during iteration — after the alias loop has returned. The
+alias stream wrapper must still fail over to the next candidate.
+"""
+
+import inspect
+
+import pytest
+import yaml
+
+from src.proxy_app.router_core import RouterCore
+
+
+@pytest.fixture
+def alias_router(tmp_path):
+    config = {
+        "free_only_mode": True,
+        "routing": {
+            "default_cooldown_seconds": 1,
+            "rate_limit_cooldown_seconds": 1,
+        },
+    }
+    config_file = tmp_path / "router_config.yaml"
+    with open(config_file, "w") as f:
+        yaml.dump(config, f)
+
+    router = RouterCore(str(config_file))
+    router.aliases = {
+        "coding": {
+            "description": "test alias",
+            "candidates": [
+                {"provider": "provider_a", "model": "model-a"},
+                {"provider": "provider_b", "model": "model-b"},
+            ],
+        }
+    }
+    return router
+
+
+async def _failing_stream():
+    yield {"delta": "partial-a"}
+    raise RuntimeError("provider A exploded mid-stream")
+
+
+async def _working_stream():
+    yield {"delta": "hello-from-b"}
+    yield {"delta": "-done"}
+
+
+def _make_route_request(call_log):
+    async def fake_route_request(request, request_id):
+        model = request.get("model", "")
+        call_log.append(model)
+        if model.startswith("provider_a/"):
+            return _failing_stream()
+        if model.startswith("provider_b/"):
+            return _working_stream()
+        raise AssertionError(f"unexpected model routed: {model}")
+
+    return fake_route_request
+
+
+class TestAliasStreamingFallback:
+    @pytest.mark.asyncio
+    async def test_stream_fails_over_to_next_alias_candidate(self, alias_router):
+        call_log = []
+        request = {"model": "coding", "stream": True, "messages": [{"role": "user", "content": "hi"}]}
+
+        # Iterate inside the patch scope: the wrapper resolves later
+        # candidates lazily, after _route_request_inner has returned.
+        with patch_route_request(alias_router, _make_route_request(call_log)):
+            result = await alias_router._route_request_inner(request, "req-stream")
+            assert inspect.isasyncgen(result), "streaming alias must return an async generator"
+            chunks = [c async for c in result]
+
+        # Candidate A yields one chunk before dying; the wrapper forwards it,
+        # then fails over to B — same partial-output semantics as
+        # _stream_with_fallback for the virtual-model path. Before the fix,
+        # the mid-stream error propagated to the client and B was never tried.
+        assert chunks == [
+            {"delta": "partial-a"},
+            {"delta": "hello-from-b"},
+            {"delta": "-done"},
+        ]
+        assert call_log == ["provider_a/model-a", "provider_b/model-b"], (
+            "must try candidate A, then fail over to candidate B"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_raises_when_all_alias_candidates_fail(self, alias_router):
+        call_log = []
+
+        async def all_failing(request, request_id):
+            call_log.append(request.get("model"))
+
+            async def stream():
+                raise RuntimeError("dead provider")
+                yield  # noqa: unreachable — makes this an async generator
+
+            return stream()
+
+        with patch_route_request(alias_router, all_failing):
+            result = await alias_router._route_request_inner(
+                {"model": "coding", "stream": True}, "req-all-fail"
+            )
+            with pytest.raises(RuntimeError, match="dead provider"):
+                _ = [c async for c in result]
+        assert len(call_log) == 2, "both alias candidates must be tried"
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_alias_unchanged(self, alias_router):
+        """Non-streaming alias resolution returns the first successful dict."""
+        call_log = []
+
+        async def fake_route_request(request, request_id):
+            call_log.append(request.get("model"))
+            return {"content": "ok-from-a"}
+
+        with patch_route_request(alias_router, fake_route_request):
+            result = await alias_router._route_request_inner({"model": "coding"}, "req-nonstream")
+
+        assert result == {"content": "ok-from-a"}
+        assert call_log == ["provider_a/model-a"]
+
+
+def patch_route_request(router, fake):
+    from unittest.mock import patch
+
+    return patch.object(router, "route_request", side_effect=fake)


### PR DESCRIPTION
## Bug

The alias fallback loop called `route_request` and wrapped it in try/except, but for **streaming** requests `route_request` returns an async generator that hasn't started. Provider errors fire later, during iteration — outside the try/except. Result: alias chains (coding/smart/fast) **never failed over for streams**; the first candidate's mid-stream error went straight to the client even when the next candidate was healthy.

## Fix

`_alias_stream_with_fallback` wrapper: when the resolved candidate returns a stream, iteration errors move to the next alias candidate — the same semantics `_stream_with_fallback` already applies to the virtual-model path, including the existing partial-chunk-then-restart tradeoff (a chunk already yielded before failure is not un-sent). Non-streaming alias resolution is untouched.

## Testing

- New `tests/test_alias_stream_fallback.py`: **3 passed** — failover to next candidate, all-candidates-failed propagation, non-streaming behavior unchanged.
- No regressions: `test_penalty_store.py` 30 passed, `test_reorder_chains.py` 22 passed.
- `test_virtual_models.py` shows 6 failures **identical on pristine origin/main** (verified via stash) — pre-existing, out of scope here.
- `tests/test_fallback_logic.py` is committed broken on main (IndentationError line 274) — also pre-existing; happy to fix in a follow-up.

## Deploy note

Takes effect on the next gateway redeploy/restart (systemd `llm-gateway` per the VPS setup).