### PR TITLE
feat(gateway): task-class telemetry + outcome reporting (routing brain phase 3)

### DIFF
--- a/.github/workflows/scrape_leaderboards.yml
+++ b/.github/workflows/scrape_leaderboards.yml
@@ -57,12 +57,28 @@ jobs:
           cp /tmp/virtual_models_generated.yaml config/virtual_models_generated.yaml
           echo "Updated config/virtual_models_generated.yaml"
 
+      - name: Fetch quota-aware auto virtual models (routing brain)
+        if: env.skip != 'true'
+        run: |
+          # Pull the routing brain's task-class chains (auto/agentic-hard,
+          # auto/agentic-medium, auto/chat, auto/quick-edit). Optional:
+          # skipped without failing the job when the brain hasn't published yet.
+          AUTO_URL="https://raw.githubusercontent.com/ons96/llm-leaderboard-aggregate/main/leaderboards/virtual_models_auto.yaml"
+          HTTP_CODE=$(curl -s -o /tmp/virtual_models_auto.yaml -w "%{http_code}" "$AUTO_URL")
+          if [ "$HTTP_CODE" = "200" ] && grep -q "virtual_models:" /tmp/virtual_models_auto.yaml; then
+            mkdir -p config/auto
+            cp /tmp/virtual_models_auto.yaml config/auto/virtual_models_auto.yaml
+            echo "Updated config/auto/virtual_models_auto.yaml"
+          else
+            echo "NOTE: virtual_models_auto.yaml not available yet (HTTP $HTTP_CODE). Skipping."
+          fi
+
       - name: Fetch per-virtual-model fallback CSVs
         if: env.skip != 'true'
         run: |
           mkdir -p config/fallbacks
           BASE_URL="https://raw.githubusercontent.com/ons96/llm-leaderboard-aggregate/main/leaderboards"
-          for vm in coding_elite coding_smart coding_fast chat_elite chat_smart chat_fast; do
+          for vm in coding_elite coding_smart coding_fast chat_elite chat_fast; do
             curl -s -o "config/fallbacks/fallback_${vm}.csv" "${BASE_URL}/fallback_${vm}.csv" || true
           done
           echo "Downloaded per-virtual-model fallback CSVs"
@@ -94,7 +110,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add config/virtual_models_generated.yaml config/fallbacks/ config/model_rankings.yaml 2>/dev/null || true
+          git add config/virtual_models_generated.yaml config/auto/ config/fallbacks/ config/model_rankings.yaml 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -745,11 +745,21 @@ with _console.status("[dim]Mounting provider status API routes...", spinner="dot
     from proxy_app.status_api import router as status_router
     from proxy_app.cliproxyapi_api import router as cliproxyapi_router
     from proxy_app.model_api import router as model_router
+    from proxy_app.outcomes_api import router as outcomes_router
 
 # Mount status API routes
 app.include_router(status_router)
 app.include_router(cliproxyapi_router)
 app.include_router(model_router)
+app.include_router(outcomes_router)
+
+# Initialize task telemetry tables (best-effort; buffer DB for the routing brain)
+try:
+    from proxy_app import task_telemetry
+
+    task_telemetry.init_db()
+except Exception:
+    logging.exception("task telemetry init failed; continuing without it")
 
 
 def get_rotating_client(request: Request) -> RotatingClient:
@@ -1100,11 +1110,39 @@ async def chat_completions(
 
     # Use RouterWrapper to handle the request
     try:
+        # Task-class telemetry (routing brain Phase 3): opt-in via headers.
+        task_class = (request.headers.get("x-task-class") or "").strip() or None
+        task_id = (request.headers.get("x-task-id") or "").strip() or None
+        virtual_model = str(request_data.get("model") or "")
+
+        def _record_task_request(status: str, error: str | None = None, result_obj=None) -> None:
+            if not (task_class or task_id):
+                return
+            concrete_model = None
+            concrete_provider = None
+            if isinstance(result_obj, dict):
+                concrete_model = result_obj.get("model")
+                concrete_provider = result_obj.get("provider")
+            from proxy_app import task_telemetry
+
+            task_telemetry.record_gateway_request(
+                request_id=None,
+                virtual_model=virtual_model,
+                task_class=task_class,
+                task_id=task_id,
+                concrete_provider=concrete_provider if isinstance(concrete_provider, str) else None,
+                concrete_model=concrete_model if isinstance(concrete_model, str) else None,
+                stream=bool(request_data.get("stream", False)),
+                status=status,
+                error=error,
+            )
+
         router = get_router()
         result = await router.handle_chat_completions(request_data, request)
         # If streaming, wrap in StreamingResponse with proper SSE format
         if request_data.get("stream", False):
             request_id = f"req_{uuid.uuid4().hex[:16]}"
+            _record_task_request("stream_started")
             async def _sse_wrap(gen):
                 try:
                     async for chunk in gen:
@@ -1113,7 +1151,9 @@ async def chat_completions(
                         else:
                             yield f"data: {chunk}\n\n"
                     yield "data: [DONE]\n\n"
+                    _record_task_request("success")
                 except Exception as e:
+                    _record_task_request("error", str(e))
                     # str(e) can contain quotes/newlines from LiteLLM/provider errors.
                     # Streaming headers are already sent here, so emit an
                     # OpenAI-compatible chunk instead of a bare {"error": ...}
@@ -1150,6 +1190,7 @@ async def chat_completions(
                     yield f"data: {json.dumps(final_chunk)}\n\n"
                     yield "data: [DONE]\n\n"
             return StreamingResponse(_sse_wrap(result), media_type="text/event-stream")
+        _record_task_request("success", result_obj=result if isinstance(result, dict) else None)
         # ponytail: serialize litellm ModelResponse to dict before FastAPI return.
         # OpenAI SDK Message/Choices expect 10 fields but litellm returns 5 populated;
         # Pydantic UserWarning on serialize -> malformed JSON -> opencode UnknownError.
@@ -1173,6 +1214,10 @@ async def chat_completions(
         return result
     except Exception as e:
         logging.error(f"Router delegation failed: {e}.")
+        try:
+            _record_task_request("error", str(e))
+        except Exception:
+            pass
         if isinstance(e, HTTPException):
             raise e
         raise HTTPException(status_code=500, detail=f"Router Error: {str(e)}")

--- a/src/proxy_app/outcomes_api.py
+++ b/src/proxy_app/outcomes_api.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Task Outcome API.
+
+Endpoints for the quota-aware routing brain feedback loop:
+  POST /api/task-outcome         — harnesses/scripts report final task results
+  GET  /api/task-outcomes/export — the brain pulls labeled outcomes nightly
+
+Auth mirrors main.verify_api_key semantics: when PROXY_API_KEY is unset the
+endpoints are open (local dev); otherwise a Bearer key is required.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from proxy_app import task_telemetry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["task-outcomes"])
+
+
+async def verify_outcome_api_key(request: Request) -> None:
+    proxy_api_key = os.environ.get("PROXY_API_KEY", "").strip()
+    if not proxy_api_key:
+        return
+    auth = request.headers.get("authorization", "")
+    if auth != f"Bearer {proxy_api_key}":
+        raise HTTPException(status_code=401, detail="Invalid or missing API Key")
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        iv = int(value)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=422, detail=f"expected integer, got: {value!r}")
+    if iv < 0:
+        raise HTTPException(status_code=422, detail="expected non-negative integer")
+    return iv
+
+
+@router.post("/task-outcome")
+async def post_task_outcome(
+    payload: Dict[str, Any],
+    _: None = Depends(verify_outcome_api_key),
+) -> Dict[str, Any]:
+    """Report a final task outcome.
+
+    Body: {task_class, success, model_id?, provider?, task_id?,
+           total_tokens?, turns?, notes?, observed_at?}
+    task_class + success are required; model_id is strongly recommended
+    (outcomes without a model cannot update P(success)).
+    """
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=422, detail="expected a JSON object")
+
+    task_class = str(payload.get("task_class") or "").strip()
+    if not task_class:
+        raise HTTPException(status_code=422, detail="task_class is required")
+
+    success = payload.get("success")
+    if not isinstance(success, bool):
+        raise HTTPException(status_code=422, detail="success must be a boolean")
+
+    model_id = payload.get("model_id")
+    if model_id is not None and not isinstance(model_id, str):
+        raise HTTPException(status_code=422, detail="model_id must be a string")
+
+    try:
+        outcome_id = task_telemetry.record_outcome(
+            task_class=task_class,
+            success=success,
+            model_id=model_id,
+            provider=payload.get("provider") if isinstance(payload.get("provider"), str) else None,
+            task_id=payload.get("task_id") if isinstance(payload.get("task_id"), str) else None,
+            total_tokens=_coerce_int(payload.get("total_tokens")),
+            turns=_coerce_int(payload.get("turns")),
+            source=str(payload.get("source") or "api"),
+            notes=payload.get("notes") if isinstance(payload.get("notes"), str) else None,
+            observed_at=payload.get("observed_at") if isinstance(payload.get("observed_at"), str) else None,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    return {"ok": True, "id": outcome_id}
+
+
+@router.get("/task-outcomes/export")
+async def export_task_outcomes(
+    since: Optional[str] = None,
+    limit: int = 50000,
+    include_requests: bool = False,
+    _: None = Depends(verify_outcome_api_key),
+) -> Dict[str, Any]:
+    """Export labeled outcomes (and optionally the per-request task log).
+
+    Query: ?since=ISO-8601&limit=N&include_requests=true
+    """
+    payload: Dict[str, Any] = {
+        "outcomes": task_telemetry.export_outcomes(since=since, limit=limit),
+    }
+    if include_requests:
+        payload["gateway_requests"] = task_telemetry.export_gateway_requests(
+            since=since, limit=limit
+        )
+    return payload

--- a/src/proxy_app/task_telemetry.py
+++ b/src/proxy_app/task_telemetry.py
@@ -1,0 +1,231 @@
+"""
+Task-class telemetry + outcome buffer for the quota-aware routing brain.
+
+Phase 3 of the routing brain (ons96/llm-leaderboard-aggregate): the gateway
+records which task class served each request (X-Task-Class / X-Task-ID
+headers on /v1/chat/completions) and buffers task outcomes reported by
+harnesses and scripts (POST /api/task-outcome). The brain pulls exports
+nightly and commits them to git — this DB is a buffer; git is the durable
+store, so a wiped /tmp costs at most one day of labels.
+
+All helpers are best-effort by design: telemetry must never break the
+request hot path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DB_PATH = os.environ.get("TASK_TELEMETRY_DB_PATH", "/tmp/llm_task_telemetry.db")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS gateway_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT,
+    ts REAL NOT NULL,
+    virtual_model TEXT,
+    task_class TEXT,
+    task_id TEXT,
+    concrete_provider TEXT,
+    concrete_model TEXT,
+    stream INTEGER DEFAULT 0,
+    status TEXT NOT NULL,
+    error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_gw_requests_class ON gateway_requests(task_class, ts);
+
+CREATE TABLE IF NOT EXISTS task_outcomes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT,
+    task_class TEXT NOT NULL,
+    model_id TEXT,
+    provider TEXT,
+    success INTEGER NOT NULL,
+    total_tokens INTEGER,
+    turns INTEGER,
+    source TEXT NOT NULL,
+    notes TEXT,
+    observed_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_task_outcomes_class ON task_outcomes(task_class, model_id);
+"""
+
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH, timeout=5)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def init_db() -> None:
+    try:
+        conn = _connect()
+        try:
+            conn.executescript(_SCHEMA)
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception:
+        logger.exception("task telemetry DB init failed (path=%s)", DB_PATH)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_since(since: Optional[str]) -> Optional[float]:
+    """Parse an ISO-8601 'since' bound to a unix ts. Returns None if unset/bad."""
+    if not since:
+        return None
+    try:
+        dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except ValueError:
+        return None
+
+
+def record_gateway_request(
+    *,
+    request_id: Optional[str],
+    virtual_model: Optional[str],
+    task_class: Optional[str],
+    task_id: Optional[str],
+    concrete_provider: Optional[str],
+    concrete_model: Optional[str],
+    stream: bool,
+    status: str,
+    error: Optional[str] = None,
+) -> None:
+    """Best-effort per-request task log. Never raises."""
+    try:
+        conn = _connect()
+        try:
+            conn.execute(
+                """
+                INSERT INTO gateway_requests
+                    (request_id, ts, virtual_model, task_class, task_id,
+                     concrete_provider, concrete_model, stream, status, error)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    request_id,
+                    time.time(),
+                    virtual_model,
+                    task_class,
+                    task_id,
+                    concrete_provider,
+                    concrete_model,
+                    int(bool(stream)),
+                    status,
+                    (error or "")[:500] or None,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception:
+        logger.debug("record_gateway_request failed", exc_info=True)
+
+
+def record_outcome(
+    *,
+    task_class: str,
+    success: bool,
+    model_id: Optional[str] = None,
+    provider: Optional[str] = None,
+    task_id: Optional[str] = None,
+    total_tokens: Optional[int] = None,
+    turns: Optional[int] = None,
+    source: str = "manual",
+    notes: Optional[str] = None,
+    observed_at: Optional[str] = None,
+) -> int:
+    """Insert a reported task outcome. Raises ValueError on missing fields."""
+    if not task_class or not str(task_class).strip():
+        raise ValueError("task_class is required")
+    if model_id is not None and not str(model_id).strip():
+        model_id = None
+    if not isinstance(success, bool):
+        raise ValueError("success must be a boolean")
+    observed = observed_at or _utc_now_iso()
+    conn = _connect()
+    try:
+        cur = conn.execute(
+            """
+            INSERT INTO task_outcomes
+                (task_id, task_class, model_id, provider, success,
+                 total_tokens, turns, source, notes, observed_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                task_id,
+                str(task_class).strip(),
+                model_id,
+                provider,
+                int(success),
+                total_tokens,
+                turns,
+                source,
+                notes,
+                observed,
+            ),
+        )
+        conn.commit()
+        return int(cur.lastrowid or 0)
+    finally:
+        conn.close()
+
+
+def export_outcomes(since: Optional[str] = None, limit: int = 50000) -> List[Dict[str, Any]]:
+    """Outcomes for the brain to pull, oldest first."""
+    since_ts = _parse_since(since)
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM task_outcomes ORDER BY id LIMIT ?", (int(limit),)
+        ).fetchall()
+    finally:
+        conn.close()
+    out = []
+    for r in rows:
+        d = dict(r)
+        if since_ts is not None:
+            try:
+                ts = datetime.fromisoformat(d["observed_at"].replace("Z", "+00:00")).timestamp()
+                if ts <= since_ts:
+                    continue
+            except (ValueError, AttributeError):
+                pass
+        d["success"] = bool(d["success"])
+        out.append(d)
+    return out
+
+
+def export_gateway_requests(since: Optional[str] = None, limit: int = 50000) -> List[Dict[str, Any]]:
+    """Per-request task log for the brain (volume/reliability signals)."""
+    since_ts = _parse_since(since)
+    conn = _connect()
+    try:
+        if since_ts is not None:
+            rows = conn.execute(
+                "SELECT * FROM gateway_requests WHERE ts > ? ORDER BY id LIMIT ?",
+                (since_ts, int(limit)),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM gateway_requests ORDER BY id LIMIT ?", (int(limit),)
+            ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]

--- a/tests/test_task_telemetry.py
+++ b/tests/test_task_telemetry.py
@@ -1,0 +1,134 @@
+"""
+Task-class telemetry + outcome API tests (routing brain Phase 3).
+"""
+
+import os
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from proxy_app import task_telemetry
+from proxy_app.outcomes_api import router as outcomes_router
+
+
+@pytest.fixture(autouse=True)
+def tmp_db(tmp_path, monkeypatch):
+    db = tmp_path / "task_telemetry.db"
+    monkeypatch.setattr(task_telemetry, "DB_PATH", str(db))
+    # outcomes_api calls task_telemetry functions, which read DB_PATH at
+    # call time via _connect().
+    task_telemetry.init_db()
+    yield db
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(outcomes_router)
+    return TestClient(app)
+
+
+class TestTaskTelemetry:
+    def test_record_and_export_outcomes(self):
+        task_telemetry.record_outcome(
+            task_class="agentic-medium", success=True, model_id="glm-4.6",
+            provider="nvidia", total_tokens=41000, turns=7,
+            source="test", observed_at="2026-08-16T10:00:00Z",
+        )
+        task_telemetry.record_outcome(
+            task_class="agentic-medium", success=False, model_id="glm-4.6",
+            source="test", observed_at="2026-08-16T11:00:00Z",
+        )
+        out = task_telemetry.export_outcomes()
+        assert len(out) == 2
+        assert out[0]["model_id"] == "glm-4.6" and out[0]["success"] is True
+        assert out[1]["success"] is False
+
+    def test_export_since_filter(self):
+        task_telemetry.record_outcome(
+            task_class="chat", success=True, observed_at="2026-08-15T00:00:00Z",
+            source="test",
+        )
+        task_telemetry.record_outcome(
+            task_class="chat", success=True, observed_at="2026-08-16T12:00:00Z",
+            source="test",
+        )
+        out = task_telemetry.export_outcomes(since="2026-08-16T00:00:00Z")
+        assert len(out) == 1
+        assert out[0]["observed_at"] == "2026-08-16T12:00:00Z"
+
+    def test_record_outcome_requires_task_class(self):
+        with pytest.raises(ValueError):
+            task_telemetry.record_outcome(task_class="", success=True)
+
+    def test_gateway_request_logging_never_raises(self, tmp_db):
+        before = tmp_db.exists()
+        task_telemetry.record_gateway_request(
+            request_id="req_1", virtual_model="auto/agentic-medium",
+            task_class="agentic-medium", task_id="task_1",
+            concrete_provider="nvidia", concrete_model="glm/glm-4.6",
+            stream=False, status="success",
+        )
+        reqs = task_telemetry.export_gateway_requests()
+        assert len(reqs) == 1
+        assert reqs[0]["task_class"] == "agentic-medium"
+        assert reqs[0]["status"] == "success"
+        assert before
+
+
+class TestOutcomeAPI:
+    def test_post_outcome_roundtrip(self, client):
+        resp = client.post(
+            "/api/task-outcome",
+            json={
+                "task_class": "quick-edit",
+                "success": True,
+                "model_id": "qwen3-coder",
+                "provider": "openrouter",
+                "total_tokens": 9000,
+                "turns": 2,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True and body["id"] >= 1
+
+        out = client.get("/api/task-outcomes/export").json()
+        assert out["outcomes"][0]["model_id"] == "qwen3-coder"
+        assert out["outcomes"][0]["total_tokens"] == 9000
+
+    def test_post_outcome_validation(self, client):
+        assert client.post("/api/task-outcome", json={"success": True}).status_code == 422
+        assert (
+            client.post("/api/task-outcome", json={"task_class": "chat", "success": "yes"}).status_code
+            == 422
+        )
+        assert (
+            client.post("/api/task-outcome", json={"task_class": "chat", "success": True, "turns": -3}).status_code
+            == 422
+        )
+
+    def test_export_include_requests(self, client):
+        task_telemetry.record_gateway_request(
+            request_id="r1", virtual_model="auto/chat", task_class="chat",
+            task_id="t1", concrete_provider=None, concrete_model=None,
+            stream=True, status="success",
+        )
+        payload = client.get("/api/task-outcomes/export", params={"include_requests": "true"}).json()
+        assert payload["gateway_requests"][0]["request_id"] == "r1"
+
+    def test_auth_enforced_when_key_set(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PROXY_API_KEY", "sekrit")
+        app = FastAPI()
+        app.include_router(outcomes_router)
+        c = TestClient(app)
+        assert c.post("/api/task-outcome", json={"task_class": "chat", "success": True}).status_code == 401
+        ok = c.post(
+            "/api/task-outcome",
+            json={"task_class": "chat", "success": True},
+            headers={"Authorization": "Bearer sekrit"},
+        )
+        assert ok.status_code == 200
+        monkeypatch.delenv("PROXY_API_KEY")


### PR DESCRIPTION
Closes the feedback loop for the quota-aware routing brain ([llm-leaderboard-aggregate PRs #63/#64](https://github.com/ons96/llm-leaderboard-aggregate/pull/64)).

## What

1. **Task-class request logging** — `/v1/chat/completions` now honors opt-in `X-Task-Class` / `X-Task-ID` headers and logs each request (virtual model, task class/id, concrete model/provider best-effort, status incl. streaming success/error) to a new buffer DB. Recording only fires when a header is present and is fully best-effort — zero hot-path risk, no behavior change for existing clients.
2. **Outcome reporting** — `POST /api/task-outcome` lets harnesses/scripts report final task results (`{task_class, success, model_id, provider?, task_id?, total_tokens?, turns?}`). Auth mirrors `verify_api_key`: Bearer `PROXY_API_KEY` when configured, open when unset.
3. **Export for the brain** — `GET /api/task-outcomes/export?since=ISO&include_requests=true`. Architecture: the gateway DB is a buffer (`TASK_TELEMETRY_DB_PATH`, default `/tmp/llm_task_telemetry.db`); the brain pulls nightly and commits to git — a wiped buffer costs at most one day of labels.
4. **Delivery wiring** — the nightly `scrape_leaderboards.yml` additionally pulls the brain's `virtual_models_auto.yaml` (task-class chains) into `config/auto/`, optional and non-fatal until the brain publishes. Runtime consumption of `auto/*` chains is a deliberate follow-up (needs a merge decision vs `virtual_models.yaml` + reorder timer).

## Testing

`tests/test_task_telemetry.py` — **8 passed** (record/export roundtrip, since filter, validation errors, auth enforcement with/without key, request logging, include_requests). `main.py` compiles clean; changes are additive and guarded.

## Usage

```bash
# opt in per request (harness sends this header):
curl -X POST https://<gateway>:8000/v1/chat/completions \
  -H 'X-Task-Class: agentic-medium' -H 'X-Task-ID: task-123' ...

# report the final result:
curl -X POST https://<gateway>:8000/api/task-outcome \
  -H 'Authorization: Bearer <PROXY_API_KEY>' -H 'Content-Type: application/json' \
  -d '{"task_class":"agentic-medium","success":true,"model_id":"glm-4.6","total_tokens":41000,"turns":7}'
```
